### PR TITLE
fix: Properly handles conversion of Vortex Decimal types into Iceberg…

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -84,6 +84,8 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
         case BINARY:
           // Spark expects binary to be in another format, no?
           return GenericVortexReaders.bytes();
+        case DECIMAL:
+          return GenericVortexReaders.decimals();
         case TIMESTAMP:
         case TIMESTAMP_NANO:
           // TODO(aduffy): timestamp and date types

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.data.vortex;
 
 import dev.vortex.api.Array;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -40,6 +41,10 @@ public class GenericVortexReaders {
 
   public static VortexValueReader<Integer> ints() {
     return IntegerReader.INSTANCE;
+  }
+
+  public static VortexValueReader<BigDecimal> decimals() {
+    return DecimalReader.INSTANCE;
   }
 
   public static VortexValueReader<Long> longs() {
@@ -151,6 +156,17 @@ public class GenericVortexReaders {
     @Override
     public Long readNonNull(Array array, int row) {
       return array.getLong(row);
+    }
+  }
+
+  private static class DecimalReader implements VortexValueReader<BigDecimal> {
+    static final DecimalReader INSTANCE = new DecimalReader();
+
+    private DecimalReader() {}
+
+    @Override
+    public BigDecimal readNonNull(Array array, int row) {
+      return array.getBigDecimal(row);
     }
   }
 

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexIterable.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexIterable.java
@@ -169,7 +169,7 @@ public class VortexIterable<T> extends CloseableGroup implements CloseableIterab
     return properties.asProperties();
   }
 
-  static final String ACCESS_KEY_PREFIX = "fs.azure.account.key.";
+  static final String ACCESS_KEY_PREFIX = "fs.azure.account.key";
   static final String FIXED_TOKEN_PREFIX = "fs.azure.sas.fixed.token.";
 
   private static Map<String, String> azurePropertiesFromHadoopConf(Configuration hadoopConf) {

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -79,6 +79,8 @@ public final class VortexSchemas {
         return Types.FloatType.get();
       case PRIMITIVE_F64:
         return Types.DoubleType.get();
+      case DECIMAL:
+        return Types.DecimalType.of(data_type.getPrecision(), data_type.getScale());
       case UTF8:
         return Types.StringType.get();
       case BINARY:


### PR DESCRIPTION
… schemas.

Also adds generic reader implementation for Vortex decimals, which isn't currently used but will be in the future for row-level deletes