### PR TITLE
fix: Propagate UnconvertibleExpression through OR

### DIFF
--- a/vortex/src/main/java/org/apache/iceberg/vortex/ConvertFilterToVortex.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/ConvertFilterToVortex.java
@@ -107,7 +107,11 @@ public final class ConvertFilterToVortex extends ExpressionVisitors.ExpressionVi
 
   @Override
   public Expression or(Expression leftResult, Expression rightResult) {
-    return Binary.or(leftResult, rightResult);
+    if (leftResult == UnconvertibleExpr.INSTANCE || rightResult == UnconvertibleExpr.INSTANCE) {
+      return ALWAYS_TRUE;
+    } else {
+      return Binary.or(leftResult, rightResult);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fix for the issue identified in https://github.com/vortex-data/vortex/issues/3536

If either half of an OR is an unconvertible expression,
we reduce the entire filter to an ALWAYS_TRUE, which means
that no filtering is pushed down.

This was discovered by the TPC-DS query

```
select * from customer_address
where
  (ca_country = 'United States' AND ca_state IN( 'SC', 'IN', 'VA'))
  OR
  (ca_country = 'United States' AND ca_state IN( 'WA', 'KS', 'KY'))
```

The IN expression is not currently pushable, but we can fix that by
implementing it in Vortex.

Adding these lines makes the query complete successfully