### PR TITLE
vortex: Basic Variant IO support

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -48,7 +48,6 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.FileFormat;

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -48,6 +48,7 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.FileFormat;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -148,6 +148,12 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
 
     @Override
+    public VortexValueReader<?> variant(Types.VariantType variantType, Field variantField) {
+      // Spark 3.5 has no VariantType/VariantVal, so variant columns cannot be read here.
+      throw new UnsupportedOperationException("Variant is not supported for Spark 3.5");
+    }
+
+    @Override
     public VortexValueReader<?> primitive(Type.PrimitiveType icebergType, Field primField) {
       return switch (icebergType.typeId()) {
         case BOOLEAN -> GenericVortexReaders.bools();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.spark.ParquetBatchReadConf;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.VortexBatchReadConf;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -191,9 +193,12 @@ class SparkBatch implements Batch {
   }
 
   // conditions for using Vortex batch reads:
+  // - no variant is projected (ArrowColumnVector cannot surface a variant as Spark's VariantVal, so
+  //   variant projections fall back to the row-based reader, which does support variant)
   // - all tasks are of FileScanTask type and read only Vortex files
   private boolean useVortexBatchReads() {
-    return taskGroups.stream().allMatch(this::supportsVortexBatchReads);
+    return TypeUtil.find(expectedSchema, Type::isVariantType) == null
+        && taskGroups.stream().allMatch(this::supportsVortexBatchReads);
   }
 
   private boolean supportsVortexBatchReads(ScanTask task) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -148,6 +148,11 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
 
     @Override
+    public VortexValueReader<?> variant(Types.VariantType variantType, Field variantField) {
+      return SparkVortexValueReaders.variants();
+    }
+
+    @Override
     public VortexValueReader<?> primitive(Type.PrimitiveType icebergType, Field primField) {
       return switch (icebergType.typeId()) {
         case BOOLEAN -> GenericVortexReaders.bools();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.data;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -31,10 +33,13 @@ import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.iceberg.data.vortex.GenericVortexReaders;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.vortex.VortexValueReader;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.unsafe.types.VariantVal;
 
 public class SparkVortexValueReaders {
   private SparkVortexValueReaders() {}
@@ -60,6 +65,10 @@ public class SparkVortexValueReaders {
   public static VortexValueReader<Long> time(TimeUnit timeUnit) {
     // Spark's TimeType is stored as microseconds since midnight (Long).
     return new TimeReader(timeUnit);
+  }
+
+  public static VortexValueReader<VariantVal> variants() {
+    return VariantReader.INSTANCE;
   }
 
   static class UTF8Reader implements VortexValueReader<UTF8String> {
@@ -154,6 +163,37 @@ public class SparkVortexValueReaders {
         case MILLISECOND -> Math.multiplyExact(measure, 1_000L);
         case SECOND -> Math.multiplyExact(measure, 1_000_000L);
       };
+    }
+  }
+
+  // Converts the Iceberg Variant produced by the shared Vortex reader into Spark's VariantVal by
+  // re-serializing metadata and value to little-endian buffers (mirrors SparkParquetReaders).
+  static class VariantReader implements VortexValueReader<VariantVal> {
+    static final VariantReader INSTANCE = new VariantReader();
+
+    private final VortexValueReader<Variant> delegate = GenericVortexReaders.variants();
+
+    private VariantReader() {}
+
+    @Override
+    public VariantVal read(FieldVector vector, int row) {
+      Variant variant = delegate.read(vector, row);
+      return variant == null ? null : toVariantVal(variant);
+    }
+
+    @Override
+    public VariantVal readNonNull(FieldVector vector, int row) {
+      return toVariantVal(delegate.readNonNull(vector, row));
+    }
+
+    private static VariantVal toVariantVal(Variant variant) {
+      byte[] metadataBytes = new byte[variant.metadata().sizeInBytes()];
+      variant.metadata().writeTo(ByteBuffer.wrap(metadataBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+
+      byte[] valueBytes = new byte[variant.value().sizeInBytes()];
+      variant.value().writeTo(ByteBuffer.wrap(valueBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+
+      return new VariantVal(valueBytes, metadataBytes);
     }
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexWriter.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexWriter.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark.data;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.UUID;
 import org.apache.arrow.vector.BigIntVector;
@@ -43,9 +45,11 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.vortex.VortexValueWriter;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.unsafe.types.VariantVal;
 
 /** Writes Spark {@link InternalRow} objects to Arrow vectors for Vortex file output. */
 public class SparkVortexWriter implements VortexValueWriter<InternalRow> {
@@ -66,7 +70,7 @@ public class SparkVortexWriter implements VortexValueWriter<InternalRow> {
       FieldVector vector = root.getVector(fieldIndex);
 
       if (field.isOptional() && datum.isNullAt(fieldIndex)) {
-        vector.setNull(rowIndex);
+        writeNull(vector, field.type(), rowIndex);
         continue;
       }
 
@@ -163,9 +167,44 @@ public class SparkVortexWriter implements VortexValueWriter<InternalRow> {
         // Mark the struct slot itself as non-null for this row.
         structVector.setIndexDefined(rowIndex);
         break;
+      case VARIANT:
+        writeVariant((StructVector) vector, row.getVariant(fieldIndex), rowIndex);
+        break;
       default:
         throw new UnsupportedOperationException(
             "Unsupported Iceberg type for Vortex write: " + type);
+    }
+  }
+
+  private static void writeNull(
+      FieldVector vector, org.apache.iceberg.types.Type type, int rowIndex) {
+    if (type.isVariantType()) {
+      writeNullVariant((StructVector) vector, rowIndex);
+    } else {
+      vector.setNull(rowIndex);
+    }
+  }
+
+  // Variant storage is an Arrow struct of { required metadata, optional value }. Spark's VariantVal
+  // already holds the serialized little-endian metadata and value, so copy them straight across.
+  private static void writeVariant(StructVector vector, VariantVal variant, int rowIndex) {
+    vector.getChild("metadata", VarBinaryVector.class).setSafe(rowIndex, variant.getMetadata());
+    vector.getChild("value", VarBinaryVector.class).setSafe(rowIndex, variant.getValue());
+    vector.setIndexDefined(rowIndex);
+  }
+
+  // The metadata child is required, so a null variant still needs a valid (empty) metadata entry.
+  private static void writeNullVariant(StructVector vector, int rowIndex) {
+    vector.setNull(rowIndex);
+
+    VariantMetadata empty = VariantMetadata.empty();
+    byte[] metadataBytes = new byte[empty.sizeInBytes()];
+    empty.writeTo(ByteBuffer.wrap(metadataBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+    vector.getChild("metadata", VarBinaryVector.class).setSafe(rowIndex, metadataBytes);
+
+    VarBinaryVector valueVector = vector.getChild("value", VarBinaryVector.class);
+    if (valueVector != null) {
+      valueVector.setNull(rowIndex);
     }
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.spark.ParquetBatchReadConf;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.VortexBatchReadConf;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -191,9 +193,12 @@ class SparkBatch implements Batch {
   }
 
   // conditions for using Vortex batch reads:
+  // - no variant is projected (ArrowColumnVector cannot surface a variant as Spark's VariantVal, so
+  //   variant projections fall back to the row-based reader, which does support variant)
   // - all tasks are of FileScanTask type and read only Vortex files
   private boolean useVortexBatchReads() {
-    return taskGroups.stream().allMatch(this::supportsVortexBatchReads);
+    return TypeUtil.find(expectedSchema, Type::isVariantType) == null
+        && taskGroups.stream().allMatch(this::supportsVortexBatchReads);
   }
 
   private boolean supportsVortexBatchReads(ScanTask task) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVortexVariantRead.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVortexVariantRead.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.spark.sql.Row;
+import org.apache.spark.types.variant.Variant;
+import org.apache.spark.unsafe.types.VariantVal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trips VARIANT columns through Vortex-format tables via Spark SQL.
+ *
+ * <p>Vortex reads default to the columnar ({@code ColumnarBatch}) path, but that path cannot
+ * surface a variant as Spark's {@link VariantVal}, so {@code SparkBatch} falls back to the
+ * row-based reader whenever a variant is projected. Projecting only {@code id} keeps the columnar
+ * path; projecting a variant column exercises the row-based reader.
+ */
+public class TestSparkVortexVariantRead extends TestBase {
+
+  private static final String CATALOG = "local";
+  private static final String TABLE = CATALOG + ".default.var_vortex";
+
+  @BeforeAll
+  public static void setupCatalog() {
+    // Use a Hadoop catalog to avoid Hive schema conversion (Hive doesn't support VARIANT yet)
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".cache-enabled", "false");
+    String temp = System.getProperty("java.io.tmpdir") + "/iceberg_spark_vortex_variant_warehouse";
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".warehouse", temp);
+  }
+
+  @BeforeEach
+  public void setupTable() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+    sql(
+        "CREATE TABLE %s (id BIGINT, v1 VARIANT, v2 VARIANT) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.format.default'='vortex')",
+        TABLE);
+
+    sql("INSERT INTO %s SELECT 1, parse_json('{\"a\":1}'), parse_json('{\"x\":10}')", TABLE);
+    sql("INSERT INTO %s SELECT 2, parse_json('{\"b\":2}'), parse_json('{\"y\":20}')", TABLE);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @Test
+  public void readVariantColumns() {
+    List<Row> rows = spark.table(TABLE).select("id", "v1", "v2").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
+    assertVariantField(rows.get(0).get(1), "a", 1L);
+    assertVariantField(rows.get(0).get(2), "x", 10L);
+
+    assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
+    assertVariantField(rows.get(1).get(1), "b", 2L);
+    assertVariantField(rows.get(1).get(2), "y", 20L);
+  }
+
+  @Test
+  public void readNonVariantProjectionUsesColumnarPath() {
+    // Projecting only non-variant columns keeps the columnar Vortex path enabled and must still
+    // return correct data after the variant fallback guard was added.
+    List<Row> rows = spark.table(TABLE).select("id").orderBy("id").collectAsList();
+    assertThat(rows).extracting(row -> row.getLong(0)).containsExactly(1L, 2L);
+  }
+
+  @Test
+  public void readNullVariant() {
+    sql("INSERT INTO %s SELECT 3, NULL, NULL", TABLE);
+
+    List<Row> rows = spark.table(TABLE).select("id", "v1").where("id = 3").collectAsList();
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(1)).isNull();
+  }
+
+  private static void assertVariantField(Object value, String key, long expected) {
+    assertThat(value).isInstanceOf(VariantVal.class);
+    VariantVal variantVal = (VariantVal) value;
+    Variant variant = new Variant(variantVal.getValue(), variantVal.getMetadata());
+    Variant field = variant.getFieldByKey(key);
+    assertThat(field).isNotNull();
+    assertThat(field.getLong()).isEqualTo(expected);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -148,6 +148,11 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
 
     @Override
+    public VortexValueReader<?> variant(Types.VariantType variantType, Field variantField) {
+      return SparkVortexValueReaders.variants();
+    }
+
+    @Override
     public VortexValueReader<?> primitive(Type.PrimitiveType icebergType, Field primField) {
       return switch (icebergType.typeId()) {
         case BOOLEAN -> GenericVortexReaders.bools();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.data;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -31,10 +33,13 @@ import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.iceberg.data.vortex.GenericVortexReaders;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.vortex.VortexValueReader;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.unsafe.types.VariantVal;
 
 public class SparkVortexValueReaders {
   private SparkVortexValueReaders() {}
@@ -60,6 +65,10 @@ public class SparkVortexValueReaders {
   public static VortexValueReader<Long> time(TimeUnit timeUnit) {
     // Spark's TimeType is stored as microseconds since midnight (Long).
     return new TimeReader(timeUnit);
+  }
+
+  public static VortexValueReader<VariantVal> variants() {
+    return VariantReader.INSTANCE;
   }
 
   static class UTF8Reader implements VortexValueReader<UTF8String> {
@@ -154,6 +163,37 @@ public class SparkVortexValueReaders {
         case MILLISECOND -> Math.multiplyExact(measure, 1_000L);
         case SECOND -> Math.multiplyExact(measure, 1_000_000L);
       };
+    }
+  }
+
+  // Converts the Iceberg Variant produced by the shared Vortex reader into Spark's VariantVal by
+  // re-serializing metadata and value to little-endian buffers (mirrors SparkParquetReaders).
+  static class VariantReader implements VortexValueReader<VariantVal> {
+    static final VariantReader INSTANCE = new VariantReader();
+
+    private final VortexValueReader<Variant> delegate = GenericVortexReaders.variants();
+
+    private VariantReader() {}
+
+    @Override
+    public VariantVal read(FieldVector vector, int row) {
+      Variant variant = delegate.read(vector, row);
+      return variant == null ? null : toVariantVal(variant);
+    }
+
+    @Override
+    public VariantVal readNonNull(FieldVector vector, int row) {
+      return toVariantVal(delegate.readNonNull(vector, row));
+    }
+
+    private static VariantVal toVariantVal(Variant variant) {
+      byte[] metadataBytes = new byte[variant.metadata().sizeInBytes()];
+      variant.metadata().writeTo(ByteBuffer.wrap(metadataBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+
+      byte[] valueBytes = new byte[variant.value().sizeInBytes()];
+      variant.value().writeTo(ByteBuffer.wrap(valueBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+
+      return new VariantVal(valueBytes, metadataBytes);
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexWriter.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexWriter.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark.data;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.UUID;
 import org.apache.arrow.vector.BigIntVector;
@@ -43,9 +45,11 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.vortex.VortexValueWriter;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.unsafe.types.VariantVal;
 
 /** Writes Spark {@link InternalRow} objects to Arrow vectors for Vortex file output. */
 public class SparkVortexWriter implements VortexValueWriter<InternalRow> {
@@ -66,7 +70,7 @@ public class SparkVortexWriter implements VortexValueWriter<InternalRow> {
       FieldVector vector = root.getVector(fieldIndex);
 
       if (field.isOptional() && datum.isNullAt(fieldIndex)) {
-        vector.setNull(rowIndex);
+        writeNull(vector, field.type(), rowIndex);
         continue;
       }
 
@@ -163,9 +167,44 @@ public class SparkVortexWriter implements VortexValueWriter<InternalRow> {
         // Mark the struct slot itself as non-null for this row.
         structVector.setIndexDefined(rowIndex);
         break;
+      case VARIANT:
+        writeVariant((StructVector) vector, row.getVariant(fieldIndex), rowIndex);
+        break;
       default:
         throw new UnsupportedOperationException(
             "Unsupported Iceberg type for Vortex write: " + type);
+    }
+  }
+
+  private static void writeNull(
+      FieldVector vector, org.apache.iceberg.types.Type type, int rowIndex) {
+    if (type.isVariantType()) {
+      writeNullVariant((StructVector) vector, rowIndex);
+    } else {
+      vector.setNull(rowIndex);
+    }
+  }
+
+  // Variant storage is an Arrow struct of { required metadata, optional value }. Spark's VariantVal
+  // already holds the serialized little-endian metadata and value, so copy them straight across.
+  private static void writeVariant(StructVector vector, VariantVal variant, int rowIndex) {
+    vector.getChild("metadata", VarBinaryVector.class).setSafe(rowIndex, variant.getMetadata());
+    vector.getChild("value", VarBinaryVector.class).setSafe(rowIndex, variant.getValue());
+    vector.setIndexDefined(rowIndex);
+  }
+
+  // The metadata child is required, so a null variant still needs a valid (empty) metadata entry.
+  private static void writeNullVariant(StructVector vector, int rowIndex) {
+    vector.setNull(rowIndex);
+
+    VariantMetadata empty = VariantMetadata.empty();
+    byte[] metadataBytes = new byte[empty.sizeInBytes()];
+    empty.writeTo(ByteBuffer.wrap(metadataBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+    vector.getChild("metadata", VarBinaryVector.class).setSafe(rowIndex, metadataBytes);
+
+    VarBinaryVector valueVector = vector.getChild("value", VarBinaryVector.class);
+    if (valueVector != null) {
+      valueVector.setNull(rowIndex);
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.spark.ParquetBatchReadConf;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.VortexBatchReadConf;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -188,9 +190,12 @@ class SparkBatch implements Batch {
   }
 
   // conditions for using Vortex batch reads:
+  // - no variant is projected (ArrowColumnVector cannot surface a variant as Spark's VariantVal, so
+  //   variant projections fall back to the row-based reader, which does support variant)
   // - all tasks are of FileScanTask type and read only Vortex files
   private boolean useVortexBatchReads() {
-    return taskGroups.stream().allMatch(this::supportsVortexBatchReads);
+    return TypeUtil.find(projection, Type::isVariantType) == null
+        && taskGroups.stream().allMatch(this::supportsVortexBatchReads);
   }
 
   private boolean supportsVortexBatchReads(ScanTask task) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVortexVariantRead.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVortexVariantRead.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.spark.sql.Row;
+import org.apache.spark.types.variant.Variant;
+import org.apache.spark.unsafe.types.VariantVal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trips VARIANT columns through Vortex-format tables via Spark SQL.
+ *
+ * <p>Vortex reads default to the columnar ({@code ColumnarBatch}) path, but that path cannot
+ * surface a variant as Spark's {@link VariantVal}, so {@code SparkBatch} falls back to the
+ * row-based reader whenever a variant is projected. Projecting only {@code id} keeps the columnar
+ * path; projecting a variant column exercises the row-based reader.
+ */
+public class TestSparkVortexVariantRead extends TestBase {
+
+  private static final String CATALOG = "local";
+  private static final String TABLE = CATALOG + ".default.var_vortex";
+
+  @BeforeAll
+  public static void setupCatalog() {
+    // Use a Hadoop catalog to avoid Hive schema conversion (Hive doesn't support VARIANT yet)
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".cache-enabled", "false");
+    String temp = System.getProperty("java.io.tmpdir") + "/iceberg_spark_vortex_variant_warehouse";
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".warehouse", temp);
+  }
+
+  @BeforeEach
+  public void setupTable() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+    sql(
+        "CREATE TABLE %s (id BIGINT, v1 VARIANT, v2 VARIANT) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.format.default'='vortex')",
+        TABLE);
+
+    sql("INSERT INTO %s SELECT 1, parse_json('{\"a\":1}'), parse_json('{\"x\":10}')", TABLE);
+    sql("INSERT INTO %s SELECT 2, parse_json('{\"b\":2}'), parse_json('{\"y\":20}')", TABLE);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @Test
+  public void readVariantColumns() {
+    List<Row> rows = spark.table(TABLE).select("id", "v1", "v2").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+
+    assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
+    assertVariantField(rows.get(0).get(1), "a", 1L);
+    assertVariantField(rows.get(0).get(2), "x", 10L);
+
+    assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
+    assertVariantField(rows.get(1).get(1), "b", 2L);
+    assertVariantField(rows.get(1).get(2), "y", 20L);
+  }
+
+  @Test
+  public void readNonVariantProjectionUsesColumnarPath() {
+    // Projecting only non-variant columns keeps the columnar Vortex path enabled and must still
+    // return correct data after the variant fallback guard was added.
+    List<Row> rows = spark.table(TABLE).select("id").orderBy("id").collectAsList();
+    assertThat(rows).extracting(row -> row.getLong(0)).containsExactly(1L, 2L);
+  }
+
+  @Test
+  public void readNullVariant() {
+    sql("INSERT INTO %s SELECT 3, NULL, NULL", TABLE);
+
+    List<Row> rows = spark.table(TABLE).select("id", "v1").where("id = 3").collectAsList();
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(1)).isNull();
+  }
+
+  private static void assertVariantField(Object value, String key, long expected) {
+    assertThat(value).isInstanceOf(VariantVal.class);
+    VariantVal variantVal = (VariantVal) value;
+    Variant variant = new Variant(variantVal.getValue(), variantVal.getMetadata());
+    Variant field = variant.getFieldByKey(key);
+    assertThat(field).isNotNull();
+    assertThat(field.getLong()).isEqualTo(expected);
+  }
+}

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReader.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReader.java
@@ -170,10 +170,6 @@ public class GenericVortexReader implements VortexRowReader<Record> {
 
     @Override
     public VortexValueReader<?> primitive(Type.PrimitiveType iPrimitive, Field primField) {
-      if (VortexSchemas.isVariantField(primField)) {
-        return GenericVortexReaders.variants();
-      }
-
       if ((iPrimitive != null && iPrimitive.typeId() == Type.TypeID.UUID)
           || VortexSchemas.isUuidField(primField)) {
         return GenericVortexReaders.uuids();
@@ -193,6 +189,11 @@ public class GenericVortexReader implements VortexRowReader<Record> {
         return timestampReader(tsType);
       }
       return simpleReader(arrowType);
+    }
+
+    @Override
+    public VortexValueReader<?> variant(Types.VariantType variantType, Field variantField) {
+      return GenericVortexReaders.variants();
     }
 
     private static VortexValueReader<?> simpleReader(ArrowType arrowType) {

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReader.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReader.java
@@ -170,6 +170,10 @@ public class GenericVortexReader implements VortexRowReader<Record> {
 
     @Override
     public VortexValueReader<?> primitive(Type.PrimitiveType iPrimitive, Field primField) {
+      if (VortexSchemas.isVariantField(primField)) {
+        return GenericVortexReaders.variants();
+      }
+
       if ((iPrimitive != null && iPrimitive.typeId() == Type.TypeID.UUID)
           || VortexSchemas.isUuidField(primField)) {
         return GenericVortexReaders.uuids();

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.data.vortex;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -53,6 +54,9 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.vortex.VortexValueReader;
 
 public class GenericVortexReaders {
@@ -92,6 +96,10 @@ public class GenericVortexReaders {
 
   public static VortexValueReader<UUID> uuids() {
     return UuidReader.INSTANCE;
+  }
+
+  public static VortexValueReader<Variant> variants() {
+    return VariantReader.INSTANCE;
   }
 
   public static VortexValueReader<LocalDate> date(boolean isMillis) {
@@ -312,6 +320,77 @@ public class GenericVortexReaders {
       return (FixedSizeBinaryVector) ext.getUnderlyingVector();
     }
     return (FixedSizeBinaryVector) vector;
+  }
+
+  private static class VariantReader implements VortexValueReader<Variant> {
+    static final VariantReader INSTANCE = new VariantReader();
+
+    private VariantReader() {}
+
+    @Override
+    public Variant read(FieldVector vector, int row) {
+      StructVector storage = variantStorage(vector);
+      VarBinaryVector valueVector = storage.getChild("value", VarBinaryVector.class);
+      if (vector.isNull(row) || isMissingBinary(valueVector, row)) {
+        FieldVector typedValueVector = (FieldVector) storage.getChild("typed_value");
+        if (typedValueVector != null && !typedValueVector.isNull(row)) {
+          throw new UnsupportedOperationException(
+              "Reading shredded Variant values from Vortex is not supported yet");
+        }
+
+        return null;
+      }
+
+      return readVariant(storage, valueVector, row);
+    }
+
+    @Override
+    public Variant readNonNull(FieldVector vector, int row) {
+      StructVector storage = variantStorage(vector);
+      VarBinaryVector valueVector = storage.getChild("value", VarBinaryVector.class);
+      if (isMissingBinary(valueVector, row)) {
+        throw new UnsupportedOperationException(
+            "Reading shredded Variant values from Vortex is not supported yet");
+      }
+
+      return readVariant(storage, valueVector, row);
+    }
+
+    private Variant readVariant(StructVector storage, VarBinaryVector valueVector, int row) {
+      VarBinaryVector metadataVector = storage.getChild("metadata", VarBinaryVector.class);
+
+      if (metadataVector == null || metadataVector.isNull(row)) {
+        throw new IllegalStateException("Invalid Vortex variant: metadata is null");
+      }
+
+      byte[] metadataBytes = metadataVector.get(row);
+      byte[] valueBytes = valueVector.get(row);
+      if (metadataBytes.length == 0 || valueBytes.length == 0) {
+        throw new IllegalStateException(
+            "Invalid Vortex variant: serialized value is empty (metadata="
+                + metadataBytes.length
+                + ", value="
+                + valueBytes.length
+                + ")");
+      }
+
+      VariantMetadata metadata =
+          VariantMetadata.from(ByteBuffer.wrap(metadataBytes).order(ByteOrder.LITTLE_ENDIAN));
+      VariantValue value =
+          VariantValue.from(metadata, ByteBuffer.wrap(valueBytes).order(ByteOrder.LITTLE_ENDIAN));
+      return Variant.of(metadata, value);
+    }
+  }
+
+  private static boolean isMissingBinary(VarBinaryVector vector, int row) {
+    return vector == null || vector.isNull(row) || vector.get(row).length == 0;
+  }
+
+  private static StructVector variantStorage(FieldVector vector) {
+    if (vector instanceof ExtensionTypeVector<?> ext) {
+      return (StructVector) ext.getUnderlyingVector();
+    }
+    return (StructVector) vector;
   }
 
   private static class DateReader implements VortexValueReader<LocalDate> {

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.data.vortex;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,6 +32,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
+
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -57,6 +59,10 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.Serialized;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.vortex.VortexValueWriter;
 
 /** Writes Iceberg generic {@link Record} objects to Arrow vectors for Vortex file output. */
@@ -226,10 +232,51 @@ public class GenericVortexWriter implements VortexValueWriter<Record> {
         // Mark the struct slot itself as non-null for this row.
         structVector.setIndexDefined(rowIndex);
         break;
+      case VARIANT:
+        writeVariant((StructVector) vector, (Variant) value, rowIndex);
+
+        break;
+
       default:
         throw new UnsupportedOperationException(
             "Unsupported Iceberg type for Vortex write: " + type);
     }
+  }
+
+  private static void writeVariant(StructVector vector, Variant variant, int rowIndex) {
+    vector.setIndexDefined(rowIndex);
+
+    writeVariantMetadata(
+        vector.getChild("metadata", VarBinaryVector.class), variant.metadata(), rowIndex);
+    writeVariantValue(vector.getChild("value", VarBinaryVector.class), variant.value(), rowIndex);
+  }
+
+  private static void writeVariantMetadata(
+      VarBinaryVector vector, VariantMetadata metadata, int rowIndex) {
+    if (metadata instanceof Serialized serialized) {
+      writeSerialized(vector, serialized, rowIndex);
+      return;
+    }
+
+    ByteBuffer buffer = ByteBuffer.allocate(metadata.sizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
+    int length = metadata.writeTo(buffer, 0);
+    vector.setSafe(rowIndex, buffer, 0, length);
+  }
+
+  private static void writeVariantValue(VarBinaryVector vector, VariantValue value, int rowIndex) {
+    if (value instanceof Serialized serialized) {
+      writeSerialized(vector, serialized, rowIndex);
+      return;
+    }
+
+    ByteBuffer buffer = ByteBuffer.allocate(value.sizeInBytes()).order(ByteOrder.LITTLE_ENDIAN);
+    int length = value.writeTo(buffer, 0);
+    vector.setSafe(rowIndex, buffer, 0, length);
+  }
+
+  private static void writeSerialized(VarBinaryVector vector, Serialized serialized, int rowIndex) {
+    ByteBuffer buffer = serialized.buffer();
+    vector.setSafe(rowIndex, buffer, buffer.position(), buffer.remaining());
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -295,6 +342,10 @@ public class GenericVortexWriter implements VortexValueWriter<Record> {
     private long nullCount;
     private T min;
     private T max;
+
+    ColumnMetricsTracker(int fieldId) {
+      this(fieldId, null, null);
+    }
 
     ColumnMetricsTracker(int fieldId, Comparator<T> comparator) {
       this(fieldId, comparator, null);

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
@@ -56,6 +56,7 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.UUIDUtil;
@@ -96,7 +97,12 @@ public class GenericVortexWriter implements VortexValueWriter<Record> {
 
       ColumnMetricsTracker<Object> tracker = (ColumnMetricsTracker<Object>) trackers[fieldIndex];
       if (value == null) {
-        vector.setNull(rowIndex);
+        if (field.isRequired()) {
+          throw new IllegalArgumentException(
+              "Cannot write null value for required field: " + field);
+        }
+
+        writeNull(vector, field.type(), rowIndex);
         tracker.addNull();
         continue;
       }
@@ -236,10 +242,28 @@ public class GenericVortexWriter implements VortexValueWriter<Record> {
         writeVariant((StructVector) vector, (Variant) value, rowIndex);
 
         break;
-
       default:
         throw new UnsupportedOperationException(
             "Unsupported Iceberg type for Vortex write: " + type);
+    }
+  }
+
+  private static void writeNull(FieldVector vector, Type type, int rowIndex) {
+    if (type.isVariantType()) {
+      writeNullVariant((StructVector) vector, rowIndex);
+    } else {
+      vector.setNull(rowIndex);
+    }
+  }
+
+  private static void writeNullVariant(StructVector vector, int rowIndex) {
+    vector.setNull(rowIndex);
+    writeVariantMetadata(
+        vector.getChild("metadata", VarBinaryVector.class), VariantMetadata.empty(), rowIndex);
+
+    VarBinaryVector valueVector = vector.getChild("value", VarBinaryVector.class);
+    if (valueVector != null) {
+      valueVector.setNull(rowIndex);
     }
   }
 
@@ -275,8 +299,7 @@ public class GenericVortexWriter implements VortexValueWriter<Record> {
   }
 
   private static void writeSerialized(VarBinaryVector vector, Serialized serialized, int rowIndex) {
-    ByteBuffer buffer = serialized.buffer();
-    vector.setSafe(rowIndex, buffer, buffer.position(), buffer.remaining());
+    vector.setSafe(rowIndex, ByteBuffers.toByteArray(serialized.buffer()));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
@@ -343,7 +343,7 @@ public class GenericVortexWriter implements VortexValueWriter<Record> {
               v -> ChronoUnit.NANOS.between(LOCAL_EPOCH, (LocalDateTime) v));
         }
       default:
-        if (field.type().isNestedType()) {
+        if (field.type().isNestedType() || field.type().isVariantType()) {
           // Lists, maps, and structs have no natural ordering — track counts only.
           return new ColumnMetricsTracker<>(field.fieldId(), null);
         }

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexWriter.java
@@ -32,7 +32,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexMetrics.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexMetrics.java
@@ -90,6 +90,8 @@ final class VortexMetrics {
           }
         });
 
+    addVariantValueCounts(rowCount, schema, metricsConfig, valueCounts);
+
     return new Metrics(
         rowCount,
         null, // columnSizes not available without Vortex JNI support
@@ -99,6 +101,19 @@ final class VortexMetrics {
         lowerBounds.isEmpty() ? null : lowerBounds,
         upperBounds.isEmpty() ? null : upperBounds,
         originalTypes.isEmpty() ? null : originalTypes);
+  }
+
+  private static void addVariantValueCounts(
+      long rowCount, Schema schema, MetricsConfig metricsConfig, Map<Integer, Long> valueCounts) {
+    for (Types.NestedField column : schema.columns()) {
+      int id = column.fieldId();
+      MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, id);
+      if (column.type().isVariantType()
+          && mode != MetricsModes.None.get()
+          && !valueCounts.containsKey(id)) {
+        valueCounts.put(id, rowCount);
+      }
+    }
   }
 
   private static int truncateLength(MetricsModes.MetricsMode mode) {

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
@@ -48,6 +48,10 @@ public abstract class VortexSchemaWithTypeVisitor<T> {
   }
 
   public static <T> T visit(Type iType, Field field, VortexSchemaWithTypeVisitor<T> visitor) {
+    if ((iType != null && iType.isVariantType()) || VortexSchemas.isVariantField(field)) {
+      return visitor.primitive(null, field);
+    }
+
     ArrowType arrowType = field.getType();
     if (arrowType instanceof ArrowType.Struct) {
       return visitStruct(iType != null ? iType.asStructType() : null, field.getChildren(), visitor);

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
@@ -51,7 +51,7 @@ public abstract class VortexSchemaWithTypeVisitor<T> {
 
   public static <T> T visit(Type iType, Field field, VortexSchemaWithTypeVisitor<T> visitor) {
     if ((iType != null && iType.isVariantType()) || VortexSchemas.isVariantField(field)) {
-      return visitor.variant(iType != null ? iType.asVariantType(): null, field);
+      return visitor.variant(iType != null ? iType.asVariantType() : null, field);
     }
 
     ArrowType arrowType = field.getType();

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
@@ -50,7 +50,7 @@ public abstract class VortexSchemaWithTypeVisitor<T> {
   }
 
   public static <T> T visit(Type iType, Field field, VortexSchemaWithTypeVisitor<T> visitor) {
-    if ((iType != null && iType.isVariantType()) || VortexSchemas.isVariantField(field)) {
+    if (isVariant(iType, field)) {
       return visitor.variant(iType != null ? iType.asVariantType() : null, field);
     }
 
@@ -67,6 +67,10 @@ public abstract class VortexSchemaWithTypeVisitor<T> {
     } else {
       return visitor.primitive(iType != null ? iType.asPrimitiveType() : null, field);
     }
+  }
+
+  private static boolean isVariant(Type iType, Field field) {
+    return (iType != null && iType.isVariantType()) || VortexSchemas.isVariantField(field);
   }
 
   private static <T> T visitStruct(

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemaWithTypeVisitor.java
@@ -40,6 +40,8 @@ public abstract class VortexSchemaWithTypeVisitor<T> {
 
   public abstract T primitive(Type.PrimitiveType iPrimitive, Field primField);
 
+  public abstract T variant(Types.VariantType variantType, Field variantField);
+
   public static <T> T visit(
       Schema expectedSchema,
       org.apache.arrow.vector.types.pojo.Schema fileSchema,
@@ -49,7 +51,7 @@ public abstract class VortexSchemaWithTypeVisitor<T> {
 
   public static <T> T visit(Type iType, Field field, VortexSchemaWithTypeVisitor<T> visitor) {
     if ((iType != null && iType.isVariantType()) || VortexSchemas.isVariantField(field)) {
-      return visitor.primitive(null, field);
+      return visitor.variant(iType != null ? iType.asVariantType(): null, field);
     }
 
     ArrowType arrowType = field.getType();

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -31,6 +31,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -519,6 +520,7 @@ public final class VortexSchemas {
     }
 
     if (isVariantField(field)) {
+      validateVariantField(field);
       return Types.VariantType.get();
     }
 
@@ -648,6 +650,69 @@ public final class VortexSchemas {
       case HALF ->
           throw new UnsupportedOperationException("Half-precision floats are not supported");
     };
+  }
+  
+  private static void validateVariantField(Field field) {
+    Preconditions.checkArgument(
+        field.getType() instanceof ArrowType.Struct,
+        "Invalid Arrow variant field %s: expected struct storage type, found %s",
+        field.getName(),
+        field.getType());
+
+    Field metadata = findChild(field, "metadata");
+    Preconditions.checkArgument(
+        metadata != null,
+        "Invalid Arrow variant field %s: missing metadata child",
+        field.getName());
+    Preconditions.checkArgument(
+        !metadata.isNullable(),
+        "Invalid Arrow variant field %s: metadata child must be non-nullable",
+        field.getName());
+    Preconditions.checkArgument(
+        isBinaryLike(metadata.getType()),
+        "Invalid Arrow variant field %s: metadata child must be binary, found %s",
+        field.getName(),
+        metadata.getType());
+
+    Field value = findChild(field, "value");
+    if (value != null) {
+      Preconditions.checkArgument(
+          value.isNullable(),
+          "Invalid Arrow variant field %s: value child must be nullable",
+          field.getName());
+      Preconditions.checkArgument(
+          isBinaryLike(value.getType()),
+          "Invalid Arrow variant field %s: value child must be binary, found %s",
+          field.getName(),
+          value.getType());
+    }
+
+    Field typedValue = findChild(field, "typed_value");
+    if (typedValue != null) {
+      Preconditions.checkArgument(
+          typedValue.isNullable(),
+          "Invalid Arrow variant field %s: typed_value child must be nullable",
+          field.getName());
+    }
+
+    Preconditions.checkArgument(
+        value != null || typedValue != null,
+        "Invalid Arrow variant field %s: expected value or typed_value child",
+        field.getName());
+  }
+
+  private static Field findChild(Field field, String name) {
+    for (Field child : field.getChildren()) {
+      if (name.equals(child.getName())) {
+        return child;
+      }
+    }
+
+    return null;
+  }
+
+  private static boolean isBinaryLike(ArrowType arrowType) {
+    return arrowType instanceof ArrowType.Binary || arrowType instanceof ArrowType.LargeBinary;
   }
 
   private static Type toIcebergTimestamp(ArrowType.Timestamp tsType) {

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -486,32 +486,7 @@ public final class VortexSchemas {
             children.build());
       }
       case VARIANT -> {
-        Map<String, String> extMetadata =
-            ImmutableMap.of(
-                ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
-                VARIANT_EXTENSION_NAME,
-                ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA,
-                "");
-
-        ImmutableList.Builder<dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field>
-            children = ImmutableList.builder();
-        children.add(
-            toVortexArrowField(
-                "metadata",
-                new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
-                false));
-        children.add(
-            toVortexArrowField(
-                "value",
-                new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
-                true));
-
-        yield toVortexArrowField(
-            name,
-            new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Struct(),
-            nullable,
-            extMetadata,
-            children.build());
+        yield toVortexVariantArrowField(name, nullable);
       }
       default ->
           throw new UnsupportedOperationException(
@@ -539,17 +514,45 @@ public final class VortexSchemas {
         children);
   }
 
+  private static dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field
+      toVortexVariantArrowField(String name, boolean nullable) {
+    Map<String, String> extMetadata =
+        ImmutableMap.of(
+            dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType
+                .EXTENSION_METADATA_KEY_NAME,
+            VARIANT_EXTENSION_NAME,
+            dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType
+                .EXTENSION_METADATA_KEY_METADATA,
+            "");
+
+    ImmutableList.Builder<dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field> children =
+        ImmutableList.builder();
+    children.add(
+        toVortexArrowField(
+            "metadata",
+            new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
+            false));
+    children.add(
+        toVortexArrowField(
+            "value",
+            new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
+            true));
+
+    return toVortexArrowField(
+        name,
+        new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Struct(),
+        nullable,
+        extMetadata,
+        children.build());
+  }
+
   private static Type toIcebergType(Field field, AtomicInteger nextId) {
     // UUID is conveyed as the {@code arrow.uuid} extension over
     // FixedSizeBinary(16). Check metadata directly so this works whether or not
     // the extension is registered with ExtensionTypeRegistry.
-    if (isUuidField(field)) {
-      return Types.UUIDType.get();
-    }
-
-    if (isVariantField(field)) {
-      validateVariantField(field);
-      return Types.VariantType.get();
+    Type extensionType = toIcebergExtensionType(field);
+    if (extensionType != null) {
+      return extensionType;
     }
 
     ArrowType arrowType = field.getType();
@@ -573,14 +576,24 @@ public final class VortexSchemas {
     return toIcebergSimpleType(arrowType);
   }
 
-  private static Type toIcebergType(
-      dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field field, AtomicInteger nextId) {
+  private static Type toIcebergExtensionType(Field field) {
     if (isUuidField(field)) {
       return Types.UUIDType.get();
     }
 
     if (isVariantField(field)) {
+      validateVariantField(field);
       return Types.VariantType.get();
+    }
+
+    return null;
+  }
+
+  private static Type toIcebergType(
+      dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field field, AtomicInteger nextId) {
+    Type extensionType = toIcebergExtensionType(field);
+    if (extensionType != null) {
+      return extensionType;
     }
 
     dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType arrowType = field.getType();
@@ -616,6 +629,19 @@ public final class VortexSchemas {
       return Types.StructType.of(convertVortexFields(field.getChildren(), nextId));
     }
     return toIcebergSimpleType(arrowType);
+  }
+
+  private static Type toIcebergExtensionType(
+      dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field field) {
+    if (isUuidField(field)) {
+      return Types.UUIDType.get();
+    }
+
+    if (isVariantField(field)) {
+      return Types.VariantType.get();
+    }
+
+    return null;
   }
 
   private static Type toIcebergSimpleType(ArrowType arrowType) {

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+
+
 public final class VortexSchemas {
   /** Canonical Arrow extension name for UUIDs (matches {@code arrow.vector.extension.UuidType}). */
   static final String UUID_EXTENSION_NAME = "arrow.uuid";
@@ -485,6 +487,34 @@ public final class VortexSchemas {
             null,
             children.build());
       }
+      case VARIANT -> {
+        Map<String, String> extMetadata =
+            ImmutableMap.of(
+                ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
+                VARIANT_EXTENSION_NAME,
+                ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA,
+                "");
+
+        ImmutableList.Builder<dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field>
+            children = ImmutableList.builder();
+        children.add(
+            toVortexArrowField(
+                "metadata",
+                new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
+                false));
+        children.add(
+            toVortexArrowField(
+                "value",
+                new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
+                nullable));
+
+        yield toVortexArrowField(
+            name,
+            new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Struct(),
+            nullable,
+            extMetadata,
+            children.build());
+      }
       default ->
           throw new UnsupportedOperationException(
               "Unsupported Iceberg type for Arrow conversion: " + type);
@@ -651,7 +681,7 @@ public final class VortexSchemas {
           throw new UnsupportedOperationException("Half-precision floats are not supported");
     };
   }
-  
+
   private static void validateVariantField(Field field) {
     Preconditions.checkArgument(
         field.getType() instanceof ArrowType.Struct,
@@ -778,7 +808,8 @@ public final class VortexSchemas {
             .get(
                 dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType
                     .EXTENSION_METADATA_KEY_NAME));
-    }
+  }
+
   public static boolean isVariantField(Field field) {
     if (field.getType() instanceof ArrowType.ExtensionType ext) {
       return VARIANT_EXTENSION_NAME.equals(ext.extensionName());

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -38,8 +38,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
-
-
 public final class VortexSchemas {
   /** Canonical Arrow extension name for UUIDs (matches {@code arrow.vector.extension.UuidType}). */
   static final String UUID_EXTENSION_NAME = "arrow.uuid";

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -41,6 +41,12 @@ public final class VortexSchemas {
   /** Canonical Arrow extension name for UUIDs (matches {@code arrow.vector.extension.UuidType}). */
   static final String UUID_EXTENSION_NAME = "arrow.uuid";
 
+  /**
+   * Canonical Arrow extension name for Parquet variant (matches {@code
+   * arrow.vector.extension.ParquetVariant}).
+   */
+  static final String VARIANT_EXTENSION_NAME = "arrow.parquet.variant";
+
   private VortexSchemas() {}
 
   /** Convert a Vortex file's Arrow {@link org.apache.arrow.vector.types.pojo.Schema} to Iceberg. */
@@ -228,6 +234,25 @@ public final class VortexSchemas {
 
         yield new Field(
             name, new FieldType(nullable, ArrowType.Struct.INSTANCE, null), children.build());
+      }
+      case VARIANT -> {
+        Map<String, String> extMetadata =
+            ImmutableMap.of(
+                ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
+                VARIANT_EXTENSION_NAME,
+                ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA,
+                "");
+
+        ImmutableList.Builder<Field> children = ImmutableList.builder();
+        children.add(
+            new Field("metadata", new FieldType(false, ArrowType.Binary.INSTANCE, null), null));
+        children.add(
+            new Field("value", new FieldType(true, ArrowType.Binary.INSTANCE, null), null));
+
+        yield new Field(
+            name,
+            new FieldType(nullable, ArrowType.Struct.INSTANCE, null, extMetadata),
+            children.build());
       }
       default ->
           throw new UnsupportedOperationException(
@@ -492,6 +517,11 @@ public final class VortexSchemas {
     if (isUuidField(field)) {
       return Types.UUIDType.get();
     }
+
+    if (isVariantField(field)) {
+      return Types.VariantType.get();
+    }
+
     ArrowType arrowType = field.getType();
     if (arrowType instanceof ArrowType.Int intType) {
       return intType.getBitWidth() <= Integer.SIZE ? Types.IntegerType.get() : Types.LongType.get();
@@ -683,5 +713,12 @@ public final class VortexSchemas {
             .get(
                 dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType
                     .EXTENSION_METADATA_KEY_NAME));
+    }
+  public static boolean isVariantField(Field field) {
+    if (field.getType() instanceof ArrowType.ExtensionType ext) {
+      return VARIANT_EXTENSION_NAME.equals(ext.extensionName());
+    }
+    return VARIANT_EXTENSION_NAME.equals(
+        field.getMetadata().get(ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME));
   }
 }

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSchemas.java
@@ -506,7 +506,7 @@ public final class VortexSchemas {
             toVortexArrowField(
                 "value",
                 new dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Binary(),
-                nullable));
+                true));
 
         yield toVortexArrowField(
             name,
@@ -580,6 +580,11 @@ public final class VortexSchemas {
     if (isUuidField(field)) {
       return Types.UUIDType.get();
     }
+
+    if (isVariantField(field)) {
+      return Types.VariantType.get();
+    }
+
     dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType arrowType = field.getType();
     if (arrowType
         instanceof dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.Int intType) {
@@ -816,5 +821,20 @@ public final class VortexSchemas {
     }
     return VARIANT_EXTENSION_NAME.equals(
         field.getMetadata().get(ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME));
+  }
+
+  public static boolean isVariantField(
+      dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field field) {
+    if (field.getType()
+        instanceof
+        dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType ext) {
+      return VARIANT_EXTENSION_NAME.equals(ext.extensionName());
+    }
+    return VARIANT_EXTENSION_NAME.equals(
+        field
+            .getMetadata()
+            .get(
+                dev.vortex.relocated.org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType
+                    .EXTENSION_METADATA_KEY_NAME));
   }
 }

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestGenericVortex.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestGenericVortex.java
@@ -48,7 +48,12 @@ public class TestGenericVortex extends DataTestBase {
 
   @Override
   protected boolean supportsVariant() {
-    return false;
+    return true;
+  }
+
+  @Override
+  protected boolean supportsTimestampNanos() {
+    return true;
   }
 
   @Override

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexMetrics.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexMetrics.java
@@ -148,6 +148,24 @@ public class TestVortexMetrics {
   }
 
   @Test
+  public void testVariantColumnReportsRowCountWithoutBounds() {
+    Schema variantSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "payload", Types.VariantType.get()));
+    FieldMetrics<Long> idMetrics = new FieldMetrics<>(1, 3, 0, 10L, 12L);
+
+    Metrics metrics =
+        VortexMetrics.buildMetrics(
+            3L, variantSchema, MetricsConfig.getDefault(), Stream.of(idMetrics));
+
+    assertThat(metrics.valueCounts()).containsEntry(2, 3L);
+    assertThat(metrics.nullValueCounts()).doesNotContainKey(2);
+    assertThat(metrics.lowerBounds()).doesNotContainKey(2);
+    assertThat(metrics.upperBounds()).doesNotContainKey(2);
+  }
+
+  @Test
   public void testMetricsNoneMode() {
     MetricsConfig noneConfig =
         MetricsConfig.fromProperties(

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexSchemas.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexSchemas.java
@@ -21,8 +21,10 @@ package org.apache.iceberg.vortex;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -32,7 +34,14 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestVortexSchemas {
+class TestVortexSchemas {
+  private static final Map<String, String> VARIANT_METADATA =
+      Map.of(
+          ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
+          VortexSchemas.VARIANT_EXTENSION_NAME,
+          ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA,
+          "");
+
   // A struct nested inside a struct, plus a list, so the conversion exercises every recursive
   // branch and id is forced to stay unique across siblings, nested structs, and list elements.
   private static final Schema SCHEMA =
@@ -55,17 +64,17 @@ public class TestVortexSchemas {
                       Types.StructType.of(required(9, "x", Types.IntegerType.get()))))));
 
   @Test
-  public void testConvertLocalArrowStructTypes() {
+  void convertLocalArrowStructTypes() {
     assertStructRoundTrip(VortexSchemas.convert(VortexSchemas.toArrowSchema(SCHEMA)));
   }
 
   @Test
-  public void testConvertRelocatedArrowStructTypes() {
+  void convertRelocatedArrowStructTypes() {
     assertStructRoundTrip(VortexSchemas.convert(VortexSchemas.toVortexArrowSchema(SCHEMA)));
   }
 
   @Test
-  public void testConvertLargeAndFixedSizeLists() {
+  void convertLargeAndFixedSizeLists() {
     // toArrowSchema only emits ArrowType.List for Iceberg lists, so build the Arrow schema directly
     // to exercise the LargeList and FixedSizeList branches a real Vortex file can produce.
     org.apache.arrow.vector.types.pojo.Schema arrowSchema =
@@ -88,9 +97,120 @@ public class TestVortexSchemas {
     assertThat(TypeUtil.indexById(converted.asStruct())).hasSize(4);
   }
 
+  @Test
+  void variantToArrowUsesCanonicalUnshreddedStorage() {
+    Schema icebergSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "v", Types.VariantType.get()));
+
+    Field variant = VortexSchemas.toArrowSchema(icebergSchema).findField("v");
+
+    assertThat(VortexSchemas.isVariantField(variant)).isTrue();
+    assertThat(variant.isNullable()).isTrue();
+    assertThat(variant.getType()).isEqualTo(ArrowType.Struct.INSTANCE);
+    assertThat(variant.getChildren()).hasSize(2);
+
+    Field metadata = variant.getChildren().get(0);
+    assertThat(metadata.getName()).isEqualTo("metadata");
+    assertThat(metadata.isNullable()).isFalse();
+    assertThat(metadata.getType()).isEqualTo(ArrowType.Binary.INSTANCE);
+
+    Field value = variant.getChildren().get(1);
+    assertThat(value.getName()).isEqualTo("value");
+    assertThat(value.isNullable()).isTrue();
+    assertThat(value.getType()).isEqualTo(ArrowType.Binary.INSTANCE);
+  }
+
+  @Test
+  void variantFromArrowAcceptsTypedValueOnlyStorage() {
+    Field variant =
+        variantField(
+            "v",
+            true,
+            List.of(
+                binaryField("metadata", false),
+                new Field(
+                    "typed_value",
+                    new FieldType(true, new ArrowType.Int(Integer.SIZE, true), null),
+                    null)));
+
+    Schema converted =
+        VortexSchemas.convert(new org.apache.arrow.vector.types.pojo.Schema(List.of(variant)));
+
+    assertThat(converted.columns()).containsExactly(optional(0, "v", Types.VariantType.get()));
+  }
+
+  @Test
+  void variantFromArrowRequiresMetadataChild() {
+    Field variant = variantField("v", true, List.of(binaryField("value", true)));
+
+    assertThatThrownBy(
+            () ->
+                VortexSchemas.convert(
+                    new org.apache.arrow.vector.types.pojo.Schema(List.of(variant))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("metadata");
+  }
+
+  @Test
+  void variantFromArrowRequiresValueOrTypedValueChild() {
+    Field variant = variantField("v", true, List.of(binaryField("metadata", false)));
+
+    assertThatThrownBy(
+            () ->
+                VortexSchemas.convert(
+                    new org.apache.arrow.vector.types.pojo.Schema(List.of(variant))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("value or typed_value");
+  }
+
+  @Test
+  void variantFromArrowRequiresNullableValueChild() {
+    Field variant =
+        variantField(
+            "v", true, List.of(binaryField("metadata", false), binaryField("value", false)));
+
+    assertThatThrownBy(
+            () ->
+                VortexSchemas.convert(
+                    new org.apache.arrow.vector.types.pojo.Schema(List.of(variant))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("value child must be nullable");
+  }
+
+  @Test
+  void variantFromArrowRequiresNullableTypedValueChild() {
+    Field variant =
+        variantField(
+            "v",
+            true,
+            List.of(
+                binaryField("metadata", false),
+                new Field(
+                    "typed_value",
+                    new FieldType(false, new ArrowType.Int(Integer.SIZE, true), null),
+                    null)));
+
+    assertThatThrownBy(
+            () ->
+                VortexSchemas.convert(
+                    new org.apache.arrow.vector.types.pojo.Schema(List.of(variant))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("typed_value child must be nullable");
+  }
+
   private static Field listField(String name, ArrowType listType, ArrowType elementType) {
     Field element = new Field("element", new FieldType(false, elementType, null), null);
     return new Field(name, new FieldType(true, listType, null), List.of(element));
+  }
+
+  private static Field variantField(String name, boolean nullable, List<Field> children) {
+    return new Field(
+        name, new FieldType(nullable, ArrowType.Struct.INSTANCE, null, VARIANT_METADATA), children);
+  }
+
+  private static Field binaryField(String name, boolean nullable) {
+    return new Field(name, new FieldType(nullable, ArrowType.Binary.INSTANCE, null), null);
   }
 
   private static void assertStructRoundTrip(Schema roundTrip) {

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexSchemas.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexSchemas.java
@@ -122,6 +122,22 @@ class TestVortexSchemas {
   }
 
   @Test
+  void requiredVariantToVortexArrowKeepsValueChildNullable() {
+    Schema icebergSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), required(2, "v", Types.VariantType.get()));
+
+    dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field variant =
+        VortexSchemas.toVortexArrowSchema(icebergSchema).findField("v");
+    dev.vortex.relocated.org.apache.arrow.vector.types.pojo.Field value =
+        variant.getChildren().get(1);
+
+    assertThat(variant.isNullable()).isFalse();
+    assertThat(value.getName()).isEqualTo("value");
+    assertThat(value.isNullable()).isTrue();
+  }
+
+  @Test
   void variantFromArrowAcceptsTypedValueOnlyStorage() {
     Field variant =
         variantField(


### PR DESCRIPTION
Adds basic support for variant in Vortex through the generic record-based writer.

Depends on:
- https://github.com/vortex-data/vortex/pull/8125
- https://github.com/vortex-data/vortex/pull/8129

Work that is still missing here:
- [ ] min/max bounds for variant array