### PR TITLE
By default disable arrow-java null and memory bounds checking and share vortexsession across files

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,7 +92,7 @@ spark41 = "4.1.1"
 sqlite-jdbc = "3.53.1.0"
 testcontainers = "2.0.5"
 tez08 = { strictly = "0.8.4"}  # see rich version usage explanation above
-vortex = "0.79.0"
+vortex = "0.80.0"
 # Arrow version resolved at runtime through vortex-jni; used as compileOnly where sources
 # reference view-vector classes that arrow 15 lacks.
 arrow19 = "19.0.0"

--- a/spark/v3.5/spark-runtime/runtime-deps.txt
+++ b/spark/v3.5/spark-runtime/runtime-deps.txt
@@ -10,8 +10,8 @@ com.google.guava:guava:33.6
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:3.1
 dev.failsafe:failsafe:3.3
-dev.vortex:vortex-jni:0.79
-dev.vortex:vortex-spark_2.12:0.79
+dev.vortex:vortex-jni:0.80
+dev.vortex:vortex-spark_2.12:0.80
 io.airlift:aircompressor:2.0
 io.netty:netty-buffer:4.2
 io.netty:netty-common:4.2

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.vortex.BoundVortexReader;
 import org.apache.iceberg.vortex.VortexRowReader;
 import org.apache.iceberg.vortex.VortexSchemaWithTypeVisitor;
 import org.apache.iceberg.vortex.VortexValueReader;
@@ -130,16 +131,25 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
   }
 
   @Override
-  public InternalRow read(VectorSchemaRoot batch, int row) {
+  public void newBatch(VectorSchemaRoot batch) {
     if (batchColumnIndex == null) {
       this.batchColumnIndex = resolveColumns(batch);
     }
 
-    GenericInternalRow result = container();
     for (int i = 0; i < readers.length; i++) {
       int columnIndex = batchColumnIndex[i];
-      FieldVector vector = columnIndex < 0 ? null : batch.getVector(columnIndex);
-      result.update(i, readers[i].read(vector, row));
+      if (columnIndex >= 0) {
+        readers[i].bind(batch.getVector(columnIndex));
+      }
+    }
+  }
+
+  @Override
+  public InternalRow read(int row) {
+    Preconditions.checkState(batchColumnIndex != null, "newBatch must be called before read");
+    GenericInternalRow result = container();
+    for (int i = 0; i < readers.length; i++) {
+      result.update(i, readers[i].read(row));
     }
     return result;
   }
@@ -242,7 +252,7 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
   }
 
-  static class StructReader implements VortexValueReader<InternalRow> {
+  static class StructReader extends BoundVortexReader<InternalRow> {
     // File column name backing each expected field, or null when the field is absent from the file.
     private final String[] childNames;
     private final List<VortexValueReader<?>> fieldReaders;
@@ -260,17 +270,23 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
 
     @Override
-    public InternalRow readNonNull(FieldVector vector, int row) {
+    protected void bindVector(FieldVector vector) {
       StructVector struct = (StructVector) vector;
+      for (int i = 0; i < childNames.length; i++) {
+        if (childNames[i] != null) {
+          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
+          Preconditions.checkState(
+              child != null, "Vortex batch is missing struct child: %s", childNames[i]);
+          fieldReaders.get(i).bind(child);
+        }
+      }
+    }
+
+    @Override
+    public InternalRow readNonNull(int row) {
       GenericInternalRow result = new GenericInternalRow(fieldReaders.size());
       for (int i = 0; i < fieldReaders.size(); i++) {
-        VortexValueReader<?> fieldReader = fieldReaders.get(i);
-        if (childNames[i] == null) {
-          result.update(i, fieldReader.read(null, row));
-        } else {
-          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
-          result.update(i, fieldReader.read(child, row));
-        }
+        result.update(i, fieldReaders.get(i).read(row));
       }
       return result;
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
@@ -37,6 +37,8 @@ import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.vortex.BoundVortexReader;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexValueReader;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
@@ -44,6 +46,13 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class SparkVortexValueReaders {
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; readers always check nullability before value getters,
+    // so Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private SparkVortexValueReaders() {}
 
   /**
@@ -51,28 +60,26 @@ public class SparkVortexValueReaders {
    * columns as Utf8View, while locally-built batches use regular Utf8 vectors.
    */
   public static VortexValueReader<UTF8String> utf8String(ArrowType arrowType) {
-    return arrowType instanceof ArrowType.Utf8View ? UTF8ViewReader.INSTANCE : UTF8Reader.INSTANCE;
+    return arrowType instanceof ArrowType.Utf8View ? new UTF8ViewReader() : new UTF8Reader();
   }
 
   /** Spark represents BinaryType as byte[], unlike the generic reader which yields a ByteBuffer. */
   public static VortexValueReader<byte[]> bytes(ArrowType arrowType) {
-    return arrowType instanceof ArrowType.BinaryView
-        ? BytesViewReader.INSTANCE
-        : BytesReader.INSTANCE;
+    return arrowType instanceof ArrowType.BinaryView ? new BytesViewReader() : new BytesReader();
   }
 
   /** Spark represents DecimalType as {@link Decimal}, not {@link java.math.BigDecimal}. */
   public static VortexValueReader<Decimal> decimals() {
-    return DecimalReader.INSTANCE;
+    return new DecimalReader();
   }
 
   public static VortexValueReader<Integer> date() {
-    return DateReader.INSTANCE;
+    return new DateReader();
   }
 
   public static VortexValueReader<UTF8String> uuid() {
     // Iceberg's UUID maps to Spark StringType; emit the canonical UUID string.
-    return UuidReader.INSTANCE;
+    return new UuidReader();
   }
 
   public static VortexValueReader<Long> timestamp(TimeUnit timeUnit) {
@@ -89,130 +96,167 @@ public class SparkVortexValueReaders {
     return new ListReader(elementReader);
   }
 
-  private static class ListReader implements VortexValueReader<ArrayData> {
+  private static class ListReader extends BoundVortexReader<ArrayData> {
     private final VortexValueReader<?> elementReader;
+    private ListVector listVector;
 
     private ListReader(VortexValueReader<?> elementReader) {
       this.elementReader = elementReader;
     }
 
     @Override
-    public ArrayData readNonNull(FieldVector vector, int row) {
-      ListVector list = (ListVector) vector;
-      int start = list.getElementStartIndex(row);
-      int end = list.getElementEndIndex(row);
+    protected void bindVector(FieldVector vector) {
+      this.listVector = (ListVector) vector;
+      elementReader.bind(listVector.getDataVector());
+    }
+
+    @Override
+    public ArrayData readNonNull(int row) {
+      int start = listVector.getElementStartIndex(row);
+      int end = listVector.getElementEndIndex(row);
       Object[] elements = new Object[end - start];
-      FieldVector elementVector = list.getDataVector();
       for (int index = start; index < end; index++) {
-        elements[index - start] = elementReader.read(elementVector, index);
+        elements[index - start] = elementReader.read(index);
       }
       return new GenericArrayData(elements);
     }
   }
 
-  static class UTF8Reader implements VortexValueReader<UTF8String> {
-    static final UTF8Reader INSTANCE = new UTF8Reader();
-
-    private UTF8Reader() {}
+  static class UTF8Reader extends BoundVortexReader<UTF8String> {
+    private VarCharVector stringVector;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      return UTF8String.fromBytes(((VarCharVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (VarCharVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
+      return UTF8String.fromBytes(stringVector.get(row));
     }
   }
 
-  static class UTF8ViewReader implements VortexValueReader<UTF8String> {
-    static final UTF8ViewReader INSTANCE = new UTF8ViewReader();
-
-    private UTF8ViewReader() {}
+  static class UTF8ViewReader extends BoundVortexReader<UTF8String> {
+    private ViewVarCharVector stringVector;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      return UTF8String.fromBytes(((ViewVarCharVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (ViewVarCharVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
+      return UTF8String.fromBytes(stringVector.get(row));
     }
   }
 
-  static class BytesReader implements VortexValueReader<byte[]> {
-    static final BytesReader INSTANCE = new BytesReader();
-
-    private BytesReader() {}
+  static class BytesReader extends BoundVortexReader<byte[]> {
+    private VarBinaryVector binaryVector;
 
     @Override
-    public byte[] readNonNull(FieldVector vector, int row) {
-      return ((VarBinaryVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (VarBinaryVector) vector;
+    }
+
+    @Override
+    public byte[] readNonNull(int row) {
+      return binaryVector.get(row);
     }
   }
 
-  static class BytesViewReader implements VortexValueReader<byte[]> {
-    static final BytesViewReader INSTANCE = new BytesViewReader();
-
-    private BytesViewReader() {}
+  static class BytesViewReader extends BoundVortexReader<byte[]> {
+    private ViewVarBinaryVector binaryVector;
 
     @Override
-    public byte[] readNonNull(FieldVector vector, int row) {
-      return ((ViewVarBinaryVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (ViewVarBinaryVector) vector;
+    }
+
+    @Override
+    public byte[] readNonNull(int row) {
+      return binaryVector.get(row);
     }
   }
 
-  static class DecimalReader implements VortexValueReader<Decimal> {
-    static final DecimalReader INSTANCE = new DecimalReader();
-
-    private DecimalReader() {}
+  static class DecimalReader extends BoundVortexReader<Decimal> {
+    private DecimalVector decimalVector;
 
     @Override
-    public Decimal readNonNull(FieldVector vector, int row) {
-      return Decimal.apply(((DecimalVector) vector).getObject(row));
+    protected void bindVector(FieldVector vector) {
+      this.decimalVector = (DecimalVector) vector;
+    }
+
+    @Override
+    public Decimal readNonNull(int row) {
+      return Decimal.apply(decimalVector.getObjectNotNull(row));
     }
   }
 
-  static class UuidReader implements VortexValueReader<UTF8String> {
-    static final UuidReader INSTANCE = new UuidReader();
-
-    private UuidReader() {}
+  static class UuidReader extends BoundVortexReader<UTF8String> {
+    private FixedSizeBinaryVector storage;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      FixedSizeBinaryVector storage =
+    protected void bindVector(FieldVector vector) {
+      this.storage =
           vector instanceof ExtensionTypeVector<?> ext
               ? (FixedSizeBinaryVector) ext.getUnderlyingVector()
               : (FixedSizeBinaryVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
       return UTF8String.fromString(UUIDUtil.convert(storage.get(row)).toString());
     }
   }
 
   // Spark expects DateType as Integer number of days since UNIX epoch.
-  static class DateReader implements VortexValueReader<Integer> {
-    static final DateReader INSTANCE = new DateReader();
-
-    private DateReader() {}
+  static class DateReader extends BoundVortexReader<Integer> {
+    private DateDayVector dayVector;
+    private DateMilliVector milliVector;
 
     @Override
-    public Integer readNonNull(FieldVector vector, int row) {
-      ArrowType arrowType = vector.getField().getType();
-      if (arrowType instanceof ArrowType.Date dateType
-          && dateType.getUnit() == org.apache.arrow.vector.types.DateUnit.MILLISECOND) {
-        long millis = ((DateMilliVector) vector).get(row);
-        return DateTimeUtil.microsToDays(millis * 1000L);
+    protected void bindVector(FieldVector vector) {
+      if (vector instanceof DateMilliVector dateMilliVector) {
+        this.milliVector = dateMilliVector;
+        this.dayVector = null;
+      } else {
+        this.dayVector = (DateDayVector) vector;
+        this.milliVector = null;
       }
-      return ((DateDayVector) vector).get(row);
+    }
+
+    @Override
+    public Integer readNonNull(int row) {
+      if (milliVector != null) {
+        return DateTimeUtil.microsToDays(milliVector.get(row) * 1000L);
+      }
+      return dayVector.get(row);
     }
   }
 
-  static class TimestampReader implements VortexValueReader<Long> {
+  static class TimestampReader extends BoundVortexReader<Long> {
     private final TimeUnit unit;
+    private TimeStampVector timestampVector;
+    private BigIntVector longVector;
 
     private TimestampReader(TimeUnit unit) {
       this.unit = unit;
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      long measure;
+    protected void bindVector(FieldVector vector) {
       if (vector instanceof TimeStampVector ts) {
-        measure = ts.get(row);
+        this.timestampVector = ts;
+        this.longVector = null;
       } else {
-        measure = ((BigIntVector) vector).get(row);
+        this.longVector = (BigIntVector) vector;
+        this.timestampVector = null;
       }
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      long measure = timestampVector != null ? timestampVector.get(row) : longVector.get(row);
       return switch (unit) {
         case NANOSECOND -> Math.floorDiv(measure, 1_000L);
         case MICROSECOND -> measure;
@@ -222,22 +266,39 @@ public class SparkVortexValueReaders {
     }
   }
 
-  static class TimeReader implements VortexValueReader<Long> {
+  static class TimeReader extends BoundVortexReader<Long> {
     private final TimeUnit unit;
+    private TimeMicroVector microVector;
+    private TimeNanoVector nanoVector;
+    private BigIntVector longVector;
 
     private TimeReader(TimeUnit unit) {
       this.unit = unit;
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      long measure;
+    protected void bindVector(FieldVector vector) {
+      this.microVector = null;
+      this.nanoVector = null;
+      this.longVector = null;
       if (vector instanceof TimeMicroVector tm) {
-        measure = tm.get(row);
+        this.microVector = tm;
       } else if (vector instanceof TimeNanoVector tn) {
-        measure = tn.get(row);
+        this.nanoVector = tn;
       } else {
-        measure = ((BigIntVector) vector).get(row);
+        this.longVector = (BigIntVector) vector;
+      }
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      long measure;
+      if (microVector != null) {
+        measure = microVector.get(row);
+      } else if (nanoVector != null) {
+        measure = nanoVector.get(row);
+      } else {
+        measure = longVector.get(row);
       }
       return switch (unit) {
         case NANOSECOND -> Math.floorDiv(measure, 1_000L);
@@ -247,4 +308,5 @@ public class SparkVortexValueReaders {
       };
     }
   }
+
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
@@ -308,5 +308,4 @@ public class SparkVortexValueReaders {
       };
     }
   }
-
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkVortexReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkVortexReaders.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexBatchReader;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -40,6 +41,14 @@ import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class VectorizedSparkVortexReaders {
+
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; Spark always calls isNullAt before value getters, so
+    // Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private VectorizedSparkVortexReaders() {}
 
   public static VortexBatchReader<ColumnarBatch> buildReader(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VortexArrowColumnVector.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VortexArrowColumnVector.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.util.List;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -41,8 +42,6 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
-import org.apache.arrow.vector.holders.NullableLargeVarCharHolder;
-import org.apache.arrow.vector.holders.NullableVarCharHolder;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -54,6 +53,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -331,19 +331,44 @@ class VortexArrowColumnVector extends ColumnVector {
     throw new UnsupportedOperationException("Unsupported Arrow type: " + arrowType);
   }
 
+  /**
+   * Base accessor reading vector memory directly by address (Comet-style). The null count is
+   * computed once per batch column (Arrow rescans the validity bitmap on every {@code
+   * getNullCount()} call) and null checks read the validity bit directly, skipping Arrow's per-call
+   * bounds checks. Value getters may return garbage for null slots, which is allowed by Spark's
+   * {@link ColumnVector} contract: callers check {@code isNullAt} (or {@code hasNull}) first.
+   */
   private abstract static class ArrowVectorAccessor {
+    // Marks a vector with null slots but no validity buffer (NullVector): every slot is null.
+    private static final long ALL_NULL = -1L;
+
     private final ValueVector vector;
+    private final int nullCount;
+    private final long validityAddress;
 
     ArrowVectorAccessor(ValueVector vector) {
       this.vector = vector;
+      this.nullCount = vector.getNullCount();
+      if (vector instanceof NullVector) {
+        this.validityAddress = ALL_NULL;
+      } else if (nullCount > 0) {
+        this.validityAddress = vector.getValidityBuffer().memoryAddress();
+      } else {
+        this.validityAddress = 0L;
+      }
     }
 
     final boolean isNullAt(int rowId) {
-      return vector.isNull(rowId);
+      if (nullCount == 0) {
+        return false;
+      } else if (validityAddress == ALL_NULL) {
+        return true;
+      }
+      return (Platform.getByte(null, validityAddress + (rowId >>> 3)) & (1 << (rowId & 7))) == 0;
     }
 
     final int getNullCount() {
-      return vector.getNullCount();
+      return nullCount;
     }
 
     boolean getBoolean(int rowId) {
@@ -396,175 +421,197 @@ class VortexArrowColumnVector extends ColumnVector {
   }
 
   private static final class BooleanAccessor extends ArrowVectorAccessor {
-    private final BitVector accessor;
+    private final long dataAddress;
 
     BooleanAccessor(BitVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     boolean getBoolean(int rowId) {
-      return accessor.get(rowId) == 1;
+      return (Platform.getByte(null, dataAddress + (rowId >>> 3)) & (1 << (rowId & 7))) != 0;
     }
   }
 
   private static final class ByteAccessor extends ArrowVectorAccessor {
-    private final TinyIntVector accessor;
+    private final long dataAddress;
 
     ByteAccessor(TinyIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     byte getByte(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getByte(null, dataAddress + rowId);
     }
   }
 
   private static final class ShortAccessor extends ArrowVectorAccessor {
-    private final SmallIntVector accessor;
+    private final long dataAddress;
 
     ShortAccessor(SmallIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     short getShort(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getShort(null, dataAddress + ((long) rowId << 1));
     }
   }
 
   private static final class IntAccessor extends ArrowVectorAccessor {
-    private final IntVector accessor;
+    private final long dataAddress;
 
     IntAccessor(IntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     int getInt(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getInt(null, dataAddress + ((long) rowId << 2));
     }
   }
 
   private static final class LongAccessor extends ArrowVectorAccessor {
-    private final BigIntVector accessor;
+    private final long dataAddress;
 
     LongAccessor(BigIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     long getLong(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getLong(null, dataAddress + ((long) rowId << 3));
     }
   }
 
   private static final class FloatAccessor extends ArrowVectorAccessor {
-    private final Float4Vector accessor;
+    private final long dataAddress;
 
     FloatAccessor(Float4Vector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     float getFloat(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getFloat(null, dataAddress + ((long) rowId << 2));
     }
   }
 
   private static final class DoubleAccessor extends ArrowVectorAccessor {
-    private final Float8Vector accessor;
+    private final long dataAddress;
 
     DoubleAccessor(Float8Vector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     double getDouble(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getDouble(null, dataAddress + ((long) rowId << 3));
     }
   }
 
   private static final class DecimalAccessor extends ArrowVectorAccessor {
+    private static final int TYPE_WIDTH = 16;
+
     private final DecimalVector accessor;
+    private final long dataAddress;
 
     DecimalAccessor(DecimalVector vector) {
       super(vector);
       this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     Decimal getDecimal(int rowId, int precision, int scale) {
+      if (precision <= Decimal.MAX_LONG_DIGITS()) {
+        // Arrow decimal128 values are little-endian two's complement; a value that fits in
+        // precision <= 18 digits fits in a long, so its low 8 bytes are the full value with the
+        // upper half being sign extension. Only valid on little-endian hardware.
+        long unscaled = Platform.getLong(null, dataAddress + (long) rowId * TYPE_WIDTH);
+        return Decimal.createUnsafe(unscaled, precision, scale);
+      }
       return Decimal.apply(accessor.getObject(rowId), precision, scale);
     }
   }
 
   private static final class StringAccessor extends ArrowVectorAccessor {
-    private final VarCharVector accessor;
-    private final NullableVarCharHolder stringResult = new NullableVarCharHolder();
+    private final long offsetAddress;
+    private final long dataAddress;
 
     StringAccessor(VarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.offsetAddress = vector.getOffsetBuffer().memoryAddress();
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      accessor.get(rowId, stringResult);
-      if (stringResult.isSet == 0) {
-        return null;
-      }
-      return UTF8String.fromAddress(
-          null,
-          stringResult.buffer.memoryAddress() + stringResult.start,
-          stringResult.end - stringResult.start);
+      int start = Platform.getInt(null, offsetAddress + ((long) rowId << 2));
+      int end = Platform.getInt(null, offsetAddress + ((long) (rowId + 1) << 2));
+      return UTF8String.fromAddress(null, dataAddress + start, end - start);
     }
   }
 
   private static final class LargeStringAccessor extends ArrowVectorAccessor {
-    private final LargeVarCharVector accessor;
-    private final NullableLargeVarCharHolder stringResult = new NullableLargeVarCharHolder();
+    private final long offsetAddress;
+    private final long dataAddress;
 
     LargeStringAccessor(LargeVarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.offsetAddress = vector.getOffsetBuffer().memoryAddress();
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      accessor.get(rowId, stringResult);
-      if (stringResult.isSet == 0) {
-        return null;
-      }
+      long start = Platform.getLong(null, offsetAddress + ((long) rowId << 3));
+      long end = Platform.getLong(null, offsetAddress + ((long) (rowId + 1) << 3));
       // A single string cannot be larger than the max integer size, so the cast is safe.
-      return UTF8String.fromAddress(
-          null,
-          stringResult.buffer.memoryAddress() + stringResult.start,
-          (int) (stringResult.end - stringResult.start));
+      return UTF8String.fromAddress(null, dataAddress + start, (int) (end - start));
     }
   }
 
   private static final class StringViewAccessor extends ArrowVectorAccessor {
-    private final ViewVarCharVector accessor;
+    // See the Arrow Utf8View spec: 16-byte views of {length, prefix|inline data, buffer id,
+    // offset}; values of 12 bytes or fewer are inlined into the view itself.
+    private static final int VIEW_SIZE = 16;
+    private static final int INLINE_SIZE = 12;
+
+    private final long viewAddress;
+    private final long[] dataBufferAddresses;
 
     StringViewAccessor(ViewVarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.viewAddress = vector.getDataBuffer().memoryAddress();
+      List<ArrowBuf> dataBuffers = vector.getDataBuffers();
+      this.dataBufferAddresses = new long[dataBuffers.size()];
+      for (int i = 0; i < dataBuffers.size(); i++) {
+        this.dataBufferAddresses[i] = dataBuffers.get(i).memoryAddress();
+      }
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      // View values may be inlined in the view buffer rather than contiguous in a data buffer,
-      // so copy out rather than aliasing vector memory.
-      return UTF8String.fromBytes(accessor.get(rowId));
+      long view = viewAddress + (long) rowId * VIEW_SIZE;
+      int length = Platform.getInt(null, view);
+      if (length <= INLINE_SIZE) {
+        // Inline values live in the view buffer itself, which shares the batch's lifetime, so
+        // aliasing it is as safe as aliasing a data buffer.
+        return UTF8String.fromAddress(null, view + 4, length);
+      }
+
+      int bufferIndex = Platform.getInt(null, view + 8);
+      int dataOffset = Platform.getInt(null, view + 12);
+      return UTF8String.fromAddress(null, dataBufferAddresses[bufferIndex] + dataOffset, length);
     }
   }
 
@@ -611,16 +658,16 @@ class VortexArrowColumnVector extends ColumnVector {
   }
 
   private static final class DateAccessor extends ArrowVectorAccessor {
-    private final DateDayVector accessor;
+    private final long dataAddress;
 
     DateAccessor(DateDayVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     int getInt(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getInt(null, dataAddress + ((long) rowId << 2));
     }
   }
 
@@ -631,18 +678,18 @@ class VortexArrowColumnVector extends ColumnVector {
    * matching Spark's nanosecond-to-microsecond conversions.
    */
   private static final class TimestampAccessor extends ArrowVectorAccessor {
-    private final TimeStampVector accessor;
+    private final long dataAddress;
     private final org.apache.arrow.vector.types.TimeUnit unit;
 
     TimestampAccessor(TimeStampVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
       this.unit = ((ArrowType.Timestamp) vector.getField().getType()).getUnit();
     }
 
     @Override
     long getLong(int rowId) {
-      long value = accessor.get(rowId);
+      long value = Platform.getLong(null, dataAddress + ((long) rowId << 3));
       return switch (unit) {
         case SECOND -> Math.multiplyExact(value, 1_000_000L);
         case MILLISECOND -> Math.multiplyExact(value, 1_000L);

--- a/spark/v4.0/spark-runtime/runtime-deps.txt
+++ b/spark/v4.0/spark-runtime/runtime-deps.txt
@@ -10,8 +10,8 @@ com.google.guava:guava:33.6
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:3.1
 dev.failsafe:failsafe:3.3
-dev.vortex:vortex-jni:0.79
-dev.vortex:vortex-spark_2.13:0.79
+dev.vortex:vortex-jni:0.80
+dev.vortex:vortex-spark_2.13:0.80
 io.airlift:aircompressor:2.0
 io.netty:netty-buffer:4.2
 io.netty:netty-common:4.2

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.vortex.BoundVortexReader;
 import org.apache.iceberg.vortex.VortexRowReader;
 import org.apache.iceberg.vortex.VortexSchemaWithTypeVisitor;
 import org.apache.iceberg.vortex.VortexValueReader;
@@ -130,16 +131,25 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
   }
 
   @Override
-  public InternalRow read(VectorSchemaRoot batch, int row) {
+  public void newBatch(VectorSchemaRoot batch) {
     if (batchColumnIndex == null) {
       this.batchColumnIndex = resolveColumns(batch);
     }
 
-    GenericInternalRow result = container();
     for (int i = 0; i < readers.length; i++) {
       int columnIndex = batchColumnIndex[i];
-      FieldVector vector = columnIndex < 0 ? null : batch.getVector(columnIndex);
-      result.update(i, readers[i].read(vector, row));
+      if (columnIndex >= 0) {
+        readers[i].bind(batch.getVector(columnIndex));
+      }
+    }
+  }
+
+  @Override
+  public InternalRow read(int row) {
+    Preconditions.checkState(batchColumnIndex != null, "newBatch must be called before read");
+    GenericInternalRow result = container();
+    for (int i = 0; i < readers.length; i++) {
+      result.update(i, readers[i].read(row));
     }
     return result;
   }
@@ -241,7 +251,7 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
   }
 
-  static class StructReader implements VortexValueReader<InternalRow> {
+  static class StructReader extends BoundVortexReader<InternalRow> {
     // File column name backing each expected field, or null when the field is absent from the file.
     private final String[] childNames;
     private final List<VortexValueReader<?>> fieldReaders;
@@ -259,17 +269,23 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
 
     @Override
-    public InternalRow readNonNull(FieldVector vector, int row) {
+    protected void bindVector(FieldVector vector) {
       StructVector struct = (StructVector) vector;
+      for (int i = 0; i < childNames.length; i++) {
+        if (childNames[i] != null) {
+          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
+          Preconditions.checkState(
+              child != null, "Vortex batch is missing struct child: %s", childNames[i]);
+          fieldReaders.get(i).bind(child);
+        }
+      }
+    }
+
+    @Override
+    public InternalRow readNonNull(int row) {
       GenericInternalRow result = new GenericInternalRow(fieldReaders.size());
       for (int i = 0; i < fieldReaders.size(); i++) {
-        VortexValueReader<?> fieldReader = fieldReaders.get(i);
-        if (childNames[i] == null) {
-          result.update(i, fieldReader.read(null, row));
-        } else {
-          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
-          result.update(i, fieldReader.read(child, row));
-        }
+        result.update(i, fieldReaders.get(i).read(row));
       }
       return result;
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
@@ -41,6 +41,8 @@ import org.apache.iceberg.data.vortex.GenericVortexReaders;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.vortex.BoundVortexReader;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexValueReader;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
@@ -49,6 +51,13 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
 public class SparkVortexValueReaders {
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; readers always check nullability before value getters,
+    // so Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private SparkVortexValueReaders() {}
 
   /**
@@ -56,28 +65,26 @@ public class SparkVortexValueReaders {
    * columns as Utf8View, while locally-built batches use regular Utf8 vectors.
    */
   public static VortexValueReader<UTF8String> utf8String(ArrowType arrowType) {
-    return arrowType instanceof ArrowType.Utf8View ? UTF8ViewReader.INSTANCE : UTF8Reader.INSTANCE;
+    return arrowType instanceof ArrowType.Utf8View ? new UTF8ViewReader() : new UTF8Reader();
   }
 
   /** Spark represents BinaryType as byte[], unlike the generic reader which yields a ByteBuffer. */
   public static VortexValueReader<byte[]> bytes(ArrowType arrowType) {
-    return arrowType instanceof ArrowType.BinaryView
-        ? BytesViewReader.INSTANCE
-        : BytesReader.INSTANCE;
+    return arrowType instanceof ArrowType.BinaryView ? new BytesViewReader() : new BytesReader();
   }
 
   /** Spark represents DecimalType as {@link Decimal}, not {@link java.math.BigDecimal}. */
   public static VortexValueReader<Decimal> decimals() {
-    return DecimalReader.INSTANCE;
+    return new DecimalReader();
   }
 
   public static VortexValueReader<Integer> date() {
-    return DateReader.INSTANCE;
+    return new DateReader();
   }
 
   public static VortexValueReader<UTF8String> uuid() {
     // Iceberg's UUID maps to Spark StringType; emit the canonical UUID string.
-    return UuidReader.INSTANCE;
+    return new UuidReader();
   }
 
   public static VortexValueReader<Long> timestamp(TimeUnit timeUnit) {
@@ -91,137 +98,174 @@ public class SparkVortexValueReaders {
   }
 
   public static VortexValueReader<VariantVal> variants() {
-    return VariantReader.INSTANCE;
+    return new VariantReader();
   }
 
   static VortexValueReader<ArrayData> list(VortexValueReader<?> elementReader) {
     return new ListReader(elementReader);
   }
 
-  private static class ListReader implements VortexValueReader<ArrayData> {
+  private static class ListReader extends BoundVortexReader<ArrayData> {
     private final VortexValueReader<?> elementReader;
+    private ListVector listVector;
 
     private ListReader(VortexValueReader<?> elementReader) {
       this.elementReader = elementReader;
     }
 
     @Override
-    public ArrayData readNonNull(FieldVector vector, int row) {
-      ListVector list = (ListVector) vector;
-      int start = list.getElementStartIndex(row);
-      int end = list.getElementEndIndex(row);
+    protected void bindVector(FieldVector vector) {
+      this.listVector = (ListVector) vector;
+      elementReader.bind(listVector.getDataVector());
+    }
+
+    @Override
+    public ArrayData readNonNull(int row) {
+      int start = listVector.getElementStartIndex(row);
+      int end = listVector.getElementEndIndex(row);
       Object[] elements = new Object[end - start];
-      FieldVector elementVector = list.getDataVector();
       for (int index = start; index < end; index++) {
-        elements[index - start] = elementReader.read(elementVector, index);
+        elements[index - start] = elementReader.read(index);
       }
       return new GenericArrayData(elements);
     }
   }
 
-  static class UTF8Reader implements VortexValueReader<UTF8String> {
-    static final UTF8Reader INSTANCE = new UTF8Reader();
-
-    private UTF8Reader() {}
+  static class UTF8Reader extends BoundVortexReader<UTF8String> {
+    private VarCharVector stringVector;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      return UTF8String.fromBytes(((VarCharVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (VarCharVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
+      return UTF8String.fromBytes(stringVector.get(row));
     }
   }
 
-  static class UTF8ViewReader implements VortexValueReader<UTF8String> {
-    static final UTF8ViewReader INSTANCE = new UTF8ViewReader();
-
-    private UTF8ViewReader() {}
+  static class UTF8ViewReader extends BoundVortexReader<UTF8String> {
+    private ViewVarCharVector stringVector;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      return UTF8String.fromBytes(((ViewVarCharVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (ViewVarCharVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
+      return UTF8String.fromBytes(stringVector.get(row));
     }
   }
 
-  static class BytesReader implements VortexValueReader<byte[]> {
-    static final BytesReader INSTANCE = new BytesReader();
-
-    private BytesReader() {}
+  static class BytesReader extends BoundVortexReader<byte[]> {
+    private VarBinaryVector binaryVector;
 
     @Override
-    public byte[] readNonNull(FieldVector vector, int row) {
-      return ((VarBinaryVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (VarBinaryVector) vector;
+    }
+
+    @Override
+    public byte[] readNonNull(int row) {
+      return binaryVector.get(row);
     }
   }
 
-  static class BytesViewReader implements VortexValueReader<byte[]> {
-    static final BytesViewReader INSTANCE = new BytesViewReader();
-
-    private BytesViewReader() {}
+  static class BytesViewReader extends BoundVortexReader<byte[]> {
+    private ViewVarBinaryVector binaryVector;
 
     @Override
-    public byte[] readNonNull(FieldVector vector, int row) {
-      return ((ViewVarBinaryVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (ViewVarBinaryVector) vector;
+    }
+
+    @Override
+    public byte[] readNonNull(int row) {
+      return binaryVector.get(row);
     }
   }
 
-  static class DecimalReader implements VortexValueReader<Decimal> {
-    static final DecimalReader INSTANCE = new DecimalReader();
-
-    private DecimalReader() {}
+  static class DecimalReader extends BoundVortexReader<Decimal> {
+    private DecimalVector decimalVector;
 
     @Override
-    public Decimal readNonNull(FieldVector vector, int row) {
-      return Decimal.apply(((DecimalVector) vector).getObject(row));
+    protected void bindVector(FieldVector vector) {
+      this.decimalVector = (DecimalVector) vector;
+    }
+
+    @Override
+    public Decimal readNonNull(int row) {
+      return Decimal.apply(decimalVector.getObjectNotNull(row));
     }
   }
 
-  static class UuidReader implements VortexValueReader<UTF8String> {
-    static final UuidReader INSTANCE = new UuidReader();
-
-    private UuidReader() {}
+  static class UuidReader extends BoundVortexReader<UTF8String> {
+    private FixedSizeBinaryVector storage;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      FixedSizeBinaryVector storage =
+    protected void bindVector(FieldVector vector) {
+      this.storage =
           vector instanceof ExtensionTypeVector<?> ext
               ? (FixedSizeBinaryVector) ext.getUnderlyingVector()
               : (FixedSizeBinaryVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
       return UTF8String.fromString(UUIDUtil.convert(storage.get(row)).toString());
     }
   }
 
   // Spark expects DateType as Integer number of days since UNIX epoch.
-  static class DateReader implements VortexValueReader<Integer> {
-    static final DateReader INSTANCE = new DateReader();
-
-    private DateReader() {}
+  static class DateReader extends BoundVortexReader<Integer> {
+    private DateDayVector dayVector;
+    private DateMilliVector milliVector;
 
     @Override
-    public Integer readNonNull(FieldVector vector, int row) {
-      ArrowType arrowType = vector.getField().getType();
-      if (arrowType instanceof ArrowType.Date dateType
-          && dateType.getUnit() == org.apache.arrow.vector.types.DateUnit.MILLISECOND) {
-        long millis = ((DateMilliVector) vector).get(row);
-        return DateTimeUtil.microsToDays(millis * 1000L);
+    protected void bindVector(FieldVector vector) {
+      if (vector instanceof DateMilliVector dateMilliVector) {
+        this.milliVector = dateMilliVector;
+        this.dayVector = null;
+      } else {
+        this.dayVector = (DateDayVector) vector;
+        this.milliVector = null;
       }
-      return ((DateDayVector) vector).get(row);
+    }
+
+    @Override
+    public Integer readNonNull(int row) {
+      if (milliVector != null) {
+        return DateTimeUtil.microsToDays(milliVector.get(row) * 1000L);
+      }
+      return dayVector.get(row);
     }
   }
 
-  static class TimestampReader implements VortexValueReader<Long> {
+  static class TimestampReader extends BoundVortexReader<Long> {
     private final TimeUnit unit;
+    private TimeStampVector timestampVector;
+    private BigIntVector longVector;
 
     private TimestampReader(TimeUnit unit) {
       this.unit = unit;
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      long measure;
+    protected void bindVector(FieldVector vector) {
       if (vector instanceof TimeStampVector ts) {
-        measure = ts.get(row);
+        this.timestampVector = ts;
+        this.longVector = null;
       } else {
-        measure = ((BigIntVector) vector).get(row);
+        this.longVector = (BigIntVector) vector;
+        this.timestampVector = null;
       }
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      long measure = timestampVector != null ? timestampVector.get(row) : longVector.get(row);
       return switch (unit) {
         case NANOSECOND -> Math.floorDiv(measure, 1_000L);
         case MICROSECOND -> measure;
@@ -231,22 +275,39 @@ public class SparkVortexValueReaders {
     }
   }
 
-  static class TimeReader implements VortexValueReader<Long> {
+  static class TimeReader extends BoundVortexReader<Long> {
     private final TimeUnit unit;
+    private TimeMicroVector microVector;
+    private TimeNanoVector nanoVector;
+    private BigIntVector longVector;
 
     private TimeReader(TimeUnit unit) {
       this.unit = unit;
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      long measure;
+    protected void bindVector(FieldVector vector) {
+      this.microVector = null;
+      this.nanoVector = null;
+      this.longVector = null;
       if (vector instanceof TimeMicroVector tm) {
-        measure = tm.get(row);
+        this.microVector = tm;
       } else if (vector instanceof TimeNanoVector tn) {
-        measure = tn.get(row);
+        this.nanoVector = tn;
       } else {
-        measure = ((BigIntVector) vector).get(row);
+        this.longVector = (BigIntVector) vector;
+      }
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      long measure;
+      if (microVector != null) {
+        measure = microVector.get(row);
+      } else if (nanoVector != null) {
+        measure = nanoVector.get(row);
+      } else {
+        measure = longVector.get(row);
       }
       return switch (unit) {
         case NANOSECOND -> Math.floorDiv(measure, 1_000L);
@@ -260,21 +321,24 @@ public class SparkVortexValueReaders {
   // Converts the Iceberg Variant produced by the shared Vortex reader into Spark's VariantVal by
   // re-serializing metadata and value to little-endian buffers (mirrors SparkParquetReaders).
   static class VariantReader implements VortexValueReader<VariantVal> {
-    static final VariantReader INSTANCE = new VariantReader();
-
     private final VortexValueReader<Variant> delegate = GenericVortexReaders.variants();
 
     private VariantReader() {}
 
     @Override
-    public VariantVal read(FieldVector vector, int row) {
-      Variant variant = delegate.read(vector, row);
+    public void bind(FieldVector vector) {
+      delegate.bind(vector);
+    }
+
+    @Override
+    public VariantVal read(int row) {
+      Variant variant = delegate.read(row);
       return variant == null ? null : toVariantVal(variant);
     }
 
     @Override
-    public VariantVal readNonNull(FieldVector vector, int row) {
-      return toVariantVal(delegate.readNonNull(vector, row));
+    public VariantVal readNonNull(int row) {
+      return toVariantVal(delegate.readNonNull(row));
     }
 
     private static VariantVal toVariantVal(Variant variant) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkVortexReaders.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkVortexReaders.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexBatchReader;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -40,6 +41,14 @@ import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class VectorizedSparkVortexReaders {
+
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; Spark always calls isNullAt before value getters, so
+    // Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private VectorizedSparkVortexReaders() {}
 
   public static VortexBatchReader<ColumnarBatch> buildReader(

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VortexArrowColumnVector.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VortexArrowColumnVector.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.util.List;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -41,8 +42,6 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
-import org.apache.arrow.vector.holders.NullableLargeVarCharHolder;
-import org.apache.arrow.vector.holders.NullableVarCharHolder;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -54,6 +53,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -331,19 +331,44 @@ class VortexArrowColumnVector extends ColumnVector {
     throw new UnsupportedOperationException("Unsupported Arrow type: " + arrowType);
   }
 
+  /**
+   * Base accessor reading vector memory directly by address (Comet-style). The null count is
+   * computed once per batch column (Arrow rescans the validity bitmap on every {@code
+   * getNullCount()} call) and null checks read the validity bit directly, skipping Arrow's per-call
+   * bounds checks. Value getters may return garbage for null slots, which is allowed by Spark's
+   * {@link ColumnVector} contract: callers check {@code isNullAt} (or {@code hasNull}) first.
+   */
   private abstract static class ArrowVectorAccessor {
+    // Marks a vector with null slots but no validity buffer (NullVector): every slot is null.
+    private static final long ALL_NULL = -1L;
+
     private final ValueVector vector;
+    private final int nullCount;
+    private final long validityAddress;
 
     ArrowVectorAccessor(ValueVector vector) {
       this.vector = vector;
+      this.nullCount = vector.getNullCount();
+      if (vector instanceof NullVector) {
+        this.validityAddress = ALL_NULL;
+      } else if (nullCount > 0) {
+        this.validityAddress = vector.getValidityBuffer().memoryAddress();
+      } else {
+        this.validityAddress = 0L;
+      }
     }
 
     final boolean isNullAt(int rowId) {
-      return vector.isNull(rowId);
+      if (nullCount == 0) {
+        return false;
+      } else if (validityAddress == ALL_NULL) {
+        return true;
+      }
+      return (Platform.getByte(null, validityAddress + (rowId >>> 3)) & (1 << (rowId & 7))) == 0;
     }
 
     final int getNullCount() {
-      return vector.getNullCount();
+      return nullCount;
     }
 
     boolean getBoolean(int rowId) {
@@ -396,175 +421,197 @@ class VortexArrowColumnVector extends ColumnVector {
   }
 
   private static final class BooleanAccessor extends ArrowVectorAccessor {
-    private final BitVector accessor;
+    private final long dataAddress;
 
     BooleanAccessor(BitVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     boolean getBoolean(int rowId) {
-      return accessor.get(rowId) == 1;
+      return (Platform.getByte(null, dataAddress + (rowId >>> 3)) & (1 << (rowId & 7))) != 0;
     }
   }
 
   private static final class ByteAccessor extends ArrowVectorAccessor {
-    private final TinyIntVector accessor;
+    private final long dataAddress;
 
     ByteAccessor(TinyIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     byte getByte(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getByte(null, dataAddress + rowId);
     }
   }
 
   private static final class ShortAccessor extends ArrowVectorAccessor {
-    private final SmallIntVector accessor;
+    private final long dataAddress;
 
     ShortAccessor(SmallIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     short getShort(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getShort(null, dataAddress + ((long) rowId << 1));
     }
   }
 
   private static final class IntAccessor extends ArrowVectorAccessor {
-    private final IntVector accessor;
+    private final long dataAddress;
 
     IntAccessor(IntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     int getInt(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getInt(null, dataAddress + ((long) rowId << 2));
     }
   }
 
   private static final class LongAccessor extends ArrowVectorAccessor {
-    private final BigIntVector accessor;
+    private final long dataAddress;
 
     LongAccessor(BigIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     long getLong(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getLong(null, dataAddress + ((long) rowId << 3));
     }
   }
 
   private static final class FloatAccessor extends ArrowVectorAccessor {
-    private final Float4Vector accessor;
+    private final long dataAddress;
 
     FloatAccessor(Float4Vector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     float getFloat(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getFloat(null, dataAddress + ((long) rowId << 2));
     }
   }
 
   private static final class DoubleAccessor extends ArrowVectorAccessor {
-    private final Float8Vector accessor;
+    private final long dataAddress;
 
     DoubleAccessor(Float8Vector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     double getDouble(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getDouble(null, dataAddress + ((long) rowId << 3));
     }
   }
 
   private static final class DecimalAccessor extends ArrowVectorAccessor {
+    private static final int TYPE_WIDTH = 16;
+
     private final DecimalVector accessor;
+    private final long dataAddress;
 
     DecimalAccessor(DecimalVector vector) {
       super(vector);
       this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     Decimal getDecimal(int rowId, int precision, int scale) {
+      if (precision <= Decimal.MAX_LONG_DIGITS()) {
+        // Arrow decimal128 values are little-endian two's complement; a value that fits in
+        // precision <= 18 digits fits in a long, so its low 8 bytes are the full value with the
+        // upper half being sign extension. Only valid on little-endian hardware.
+        long unscaled = Platform.getLong(null, dataAddress + (long) rowId * TYPE_WIDTH);
+        return Decimal.createUnsafe(unscaled, precision, scale);
+      }
       return Decimal.apply(accessor.getObject(rowId), precision, scale);
     }
   }
 
   private static final class StringAccessor extends ArrowVectorAccessor {
-    private final VarCharVector accessor;
-    private final NullableVarCharHolder stringResult = new NullableVarCharHolder();
+    private final long offsetAddress;
+    private final long dataAddress;
 
     StringAccessor(VarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.offsetAddress = vector.getOffsetBuffer().memoryAddress();
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      accessor.get(rowId, stringResult);
-      if (stringResult.isSet == 0) {
-        return null;
-      }
-      return UTF8String.fromAddress(
-          null,
-          stringResult.buffer.memoryAddress() + stringResult.start,
-          stringResult.end - stringResult.start);
+      int start = Platform.getInt(null, offsetAddress + ((long) rowId << 2));
+      int end = Platform.getInt(null, offsetAddress + ((long) (rowId + 1) << 2));
+      return UTF8String.fromAddress(null, dataAddress + start, end - start);
     }
   }
 
   private static final class LargeStringAccessor extends ArrowVectorAccessor {
-    private final LargeVarCharVector accessor;
-    private final NullableLargeVarCharHolder stringResult = new NullableLargeVarCharHolder();
+    private final long offsetAddress;
+    private final long dataAddress;
 
     LargeStringAccessor(LargeVarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.offsetAddress = vector.getOffsetBuffer().memoryAddress();
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      accessor.get(rowId, stringResult);
-      if (stringResult.isSet == 0) {
-        return null;
-      }
+      long start = Platform.getLong(null, offsetAddress + ((long) rowId << 3));
+      long end = Platform.getLong(null, offsetAddress + ((long) (rowId + 1) << 3));
       // A single string cannot be larger than the max integer size, so the cast is safe.
-      return UTF8String.fromAddress(
-          null,
-          stringResult.buffer.memoryAddress() + stringResult.start,
-          (int) (stringResult.end - stringResult.start));
+      return UTF8String.fromAddress(null, dataAddress + start, (int) (end - start));
     }
   }
 
   private static final class StringViewAccessor extends ArrowVectorAccessor {
-    private final ViewVarCharVector accessor;
+    // See the Arrow Utf8View spec: 16-byte views of {length, prefix|inline data, buffer id,
+    // offset}; values of 12 bytes or fewer are inlined into the view itself.
+    private static final int VIEW_SIZE = 16;
+    private static final int INLINE_SIZE = 12;
+
+    private final long viewAddress;
+    private final long[] dataBufferAddresses;
 
     StringViewAccessor(ViewVarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.viewAddress = vector.getDataBuffer().memoryAddress();
+      List<ArrowBuf> dataBuffers = vector.getDataBuffers();
+      this.dataBufferAddresses = new long[dataBuffers.size()];
+      for (int i = 0; i < dataBuffers.size(); i++) {
+        this.dataBufferAddresses[i] = dataBuffers.get(i).memoryAddress();
+      }
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      // View values may be inlined in the view buffer rather than contiguous in a data buffer,
-      // so copy out rather than aliasing vector memory.
-      return UTF8String.fromBytes(accessor.get(rowId));
+      long view = viewAddress + (long) rowId * VIEW_SIZE;
+      int length = Platform.getInt(null, view);
+      if (length <= INLINE_SIZE) {
+        // Inline values live in the view buffer itself, which shares the batch's lifetime, so
+        // aliasing it is as safe as aliasing a data buffer.
+        return UTF8String.fromAddress(null, view + 4, length);
+      }
+
+      int bufferIndex = Platform.getInt(null, view + 8);
+      int dataOffset = Platform.getInt(null, view + 12);
+      return UTF8String.fromAddress(null, dataBufferAddresses[bufferIndex] + dataOffset, length);
     }
   }
 
@@ -611,16 +658,16 @@ class VortexArrowColumnVector extends ColumnVector {
   }
 
   private static final class DateAccessor extends ArrowVectorAccessor {
-    private final DateDayVector accessor;
+    private final long dataAddress;
 
     DateAccessor(DateDayVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     int getInt(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getInt(null, dataAddress + ((long) rowId << 2));
     }
   }
 
@@ -631,18 +678,18 @@ class VortexArrowColumnVector extends ColumnVector {
    * matching Spark's nanosecond-to-microsecond conversions.
    */
   private static final class TimestampAccessor extends ArrowVectorAccessor {
-    private final TimeStampVector accessor;
+    private final long dataAddress;
     private final org.apache.arrow.vector.types.TimeUnit unit;
 
     TimestampAccessor(TimeStampVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
       this.unit = ((ArrowType.Timestamp) vector.getField().getType()).getUnit();
     }
 
     @Override
     long getLong(int rowId) {
-      long value = accessor.get(rowId);
+      long value = Platform.getLong(null, dataAddress + ((long) rowId << 3));
       return switch (unit) {
         case SECOND -> Math.multiplyExact(value, 1_000_000L);
         case MILLISECOND -> Math.multiplyExact(value, 1_000L);

--- a/spark/v4.1/spark-runtime/runtime-deps.txt
+++ b/spark/v4.1/spark-runtime/runtime-deps.txt
@@ -10,8 +10,8 @@ com.google.guava:guava:33.6
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:3.1
 dev.failsafe:failsafe:3.3
-dev.vortex:vortex-jni:0.79
-dev.vortex:vortex-spark_2.13:0.79
+dev.vortex:vortex-jni:0.80
+dev.vortex:vortex-spark_2.13:0.80
 io.airlift:aircompressor:2.0
 io.netty:netty-buffer:4.2
 io.netty:netty-common:4.2

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexReader.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.vortex.BoundVortexReader;
 import org.apache.iceberg.vortex.VortexRowReader;
 import org.apache.iceberg.vortex.VortexSchemaWithTypeVisitor;
 import org.apache.iceberg.vortex.VortexValueReader;
@@ -130,16 +131,25 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
   }
 
   @Override
-  public InternalRow read(VectorSchemaRoot batch, int row) {
+  public void newBatch(VectorSchemaRoot batch) {
     if (batchColumnIndex == null) {
       this.batchColumnIndex = resolveColumns(batch);
     }
 
-    GenericInternalRow result = container();
     for (int i = 0; i < readers.length; i++) {
       int columnIndex = batchColumnIndex[i];
-      FieldVector vector = columnIndex < 0 ? null : batch.getVector(columnIndex);
-      result.update(i, readers[i].read(vector, row));
+      if (columnIndex >= 0) {
+        readers[i].bind(batch.getVector(columnIndex));
+      }
+    }
+  }
+
+  @Override
+  public InternalRow read(int row) {
+    Preconditions.checkState(batchColumnIndex != null, "newBatch must be called before read");
+    GenericInternalRow result = container();
+    for (int i = 0; i < readers.length; i++) {
+      result.update(i, readers[i].read(row));
     }
     return result;
   }
@@ -241,7 +251,7 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
   }
 
-  static class StructReader implements VortexValueReader<InternalRow> {
+  static class StructReader extends BoundVortexReader<InternalRow> {
     // File column name backing each expected field, or null when the field is absent from the file.
     private final String[] childNames;
     private final List<VortexValueReader<?>> fieldReaders;
@@ -259,17 +269,23 @@ public class SparkVortexReader implements VortexRowReader<InternalRow> {
     }
 
     @Override
-    public InternalRow readNonNull(FieldVector vector, int row) {
+    protected void bindVector(FieldVector vector) {
       StructVector struct = (StructVector) vector;
+      for (int i = 0; i < childNames.length; i++) {
+        if (childNames[i] != null) {
+          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
+          Preconditions.checkState(
+              child != null, "Vortex batch is missing struct child: %s", childNames[i]);
+          fieldReaders.get(i).bind(child);
+        }
+      }
+    }
+
+    @Override
+    public InternalRow readNonNull(int row) {
       GenericInternalRow result = new GenericInternalRow(fieldReaders.size());
       for (int i = 0; i < fieldReaders.size(); i++) {
-        VortexValueReader<?> fieldReader = fieldReaders.get(i);
-        if (childNames[i] == null) {
-          result.update(i, fieldReader.read(null, row));
-        } else {
-          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
-          result.update(i, fieldReader.read(child, row));
-        }
+        result.update(i, fieldReaders.get(i).read(row));
       }
       return result;
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVortexValueReaders.java
@@ -41,6 +41,8 @@ import org.apache.iceberg.data.vortex.GenericVortexReaders;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.vortex.BoundVortexReader;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexValueReader;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
@@ -49,6 +51,13 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
 public class SparkVortexValueReaders {
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; Spark always calls isNullAt before value getters, so
+    // Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private SparkVortexValueReaders() {}
 
   /**
@@ -56,28 +65,26 @@ public class SparkVortexValueReaders {
    * columns as Utf8View, while locally-built batches use regular Utf8 vectors.
    */
   public static VortexValueReader<UTF8String> utf8String(ArrowType arrowType) {
-    return arrowType instanceof ArrowType.Utf8View ? UTF8ViewReader.INSTANCE : UTF8Reader.INSTANCE;
+    return arrowType instanceof ArrowType.Utf8View ? new UTF8ViewReader() : new UTF8Reader();
   }
 
   /** Spark represents BinaryType as byte[], unlike the generic reader which yields a ByteBuffer. */
   public static VortexValueReader<byte[]> bytes(ArrowType arrowType) {
-    return arrowType instanceof ArrowType.BinaryView
-        ? BytesViewReader.INSTANCE
-        : BytesReader.INSTANCE;
+    return arrowType instanceof ArrowType.BinaryView ? new BytesViewReader() : new BytesReader();
   }
 
   /** Spark represents DecimalType as {@link Decimal}, not {@link java.math.BigDecimal}. */
   public static VortexValueReader<Decimal> decimals() {
-    return DecimalReader.INSTANCE;
+    return new DecimalReader();
   }
 
   public static VortexValueReader<Integer> date() {
-    return DateReader.INSTANCE;
+    return new DateReader();
   }
 
   public static VortexValueReader<UTF8String> uuid() {
     // Iceberg's UUID maps to Spark StringType; emit the canonical UUID string.
-    return UuidReader.INSTANCE;
+    return new UuidReader();
   }
 
   public static VortexValueReader<Long> timestamp(TimeUnit timeUnit) {
@@ -91,137 +98,174 @@ public class SparkVortexValueReaders {
   }
 
   public static VortexValueReader<VariantVal> variants() {
-    return VariantReader.INSTANCE;
+    return new VariantReader();
   }
 
   static VortexValueReader<ArrayData> list(VortexValueReader<?> elementReader) {
     return new ListReader(elementReader);
   }
 
-  private static class ListReader implements VortexValueReader<ArrayData> {
+  private static class ListReader extends BoundVortexReader<ArrayData> {
     private final VortexValueReader<?> elementReader;
+    private ListVector listVector;
 
     private ListReader(VortexValueReader<?> elementReader) {
       this.elementReader = elementReader;
     }
 
     @Override
-    public ArrayData readNonNull(FieldVector vector, int row) {
-      ListVector list = (ListVector) vector;
-      int start = list.getElementStartIndex(row);
-      int end = list.getElementEndIndex(row);
+    protected void bindVector(FieldVector vector) {
+      this.listVector = (ListVector) vector;
+      elementReader.bind(listVector.getDataVector());
+    }
+
+    @Override
+    public ArrayData readNonNull(int row) {
+      int start = listVector.getElementStartIndex(row);
+      int end = listVector.getElementEndIndex(row);
       Object[] elements = new Object[end - start];
-      FieldVector elementVector = list.getDataVector();
       for (int index = start; index < end; index++) {
-        elements[index - start] = elementReader.read(elementVector, index);
+        elements[index - start] = elementReader.read(index);
       }
       return new GenericArrayData(elements);
     }
   }
 
-  static class UTF8Reader implements VortexValueReader<UTF8String> {
-    static final UTF8Reader INSTANCE = new UTF8Reader();
-
-    private UTF8Reader() {}
+  static class UTF8Reader extends BoundVortexReader<UTF8String> {
+    private VarCharVector stringVector;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      return UTF8String.fromBytes(((VarCharVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (VarCharVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
+      return UTF8String.fromBytes(stringVector.get(row));
     }
   }
 
-  static class UTF8ViewReader implements VortexValueReader<UTF8String> {
-    static final UTF8ViewReader INSTANCE = new UTF8ViewReader();
-
-    private UTF8ViewReader() {}
+  static class UTF8ViewReader extends BoundVortexReader<UTF8String> {
+    private ViewVarCharVector stringVector;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      return UTF8String.fromBytes(((ViewVarCharVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (ViewVarCharVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
+      return UTF8String.fromBytes(stringVector.get(row));
     }
   }
 
-  static class BytesReader implements VortexValueReader<byte[]> {
-    static final BytesReader INSTANCE = new BytesReader();
-
-    private BytesReader() {}
+  static class BytesReader extends BoundVortexReader<byte[]> {
+    private VarBinaryVector binaryVector;
 
     @Override
-    public byte[] readNonNull(FieldVector vector, int row) {
-      return ((VarBinaryVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (VarBinaryVector) vector;
+    }
+
+    @Override
+    public byte[] readNonNull(int row) {
+      return binaryVector.get(row);
     }
   }
 
-  static class BytesViewReader implements VortexValueReader<byte[]> {
-    static final BytesViewReader INSTANCE = new BytesViewReader();
-
-    private BytesViewReader() {}
+  static class BytesViewReader extends BoundVortexReader<byte[]> {
+    private ViewVarBinaryVector binaryVector;
 
     @Override
-    public byte[] readNonNull(FieldVector vector, int row) {
-      return ((ViewVarBinaryVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (ViewVarBinaryVector) vector;
+    }
+
+    @Override
+    public byte[] readNonNull(int row) {
+      return binaryVector.get(row);
     }
   }
 
-  static class DecimalReader implements VortexValueReader<Decimal> {
-    static final DecimalReader INSTANCE = new DecimalReader();
-
-    private DecimalReader() {}
+  static class DecimalReader extends BoundVortexReader<Decimal> {
+    private DecimalVector decimalVector;
 
     @Override
-    public Decimal readNonNull(FieldVector vector, int row) {
-      return Decimal.apply(((DecimalVector) vector).getObject(row));
+    protected void bindVector(FieldVector vector) {
+      this.decimalVector = (DecimalVector) vector;
+    }
+
+    @Override
+    public Decimal readNonNull(int row) {
+      return Decimal.apply(decimalVector.getObjectNotNull(row));
     }
   }
 
-  static class UuidReader implements VortexValueReader<UTF8String> {
-    static final UuidReader INSTANCE = new UuidReader();
-
-    private UuidReader() {}
+  static class UuidReader extends BoundVortexReader<UTF8String> {
+    private FixedSizeBinaryVector storage;
 
     @Override
-    public UTF8String readNonNull(FieldVector vector, int row) {
-      FixedSizeBinaryVector storage =
+    protected void bindVector(FieldVector vector) {
+      this.storage =
           vector instanceof ExtensionTypeVector<?> ext
               ? (FixedSizeBinaryVector) ext.getUnderlyingVector()
               : (FixedSizeBinaryVector) vector;
+    }
+
+    @Override
+    public UTF8String readNonNull(int row) {
       return UTF8String.fromString(UUIDUtil.convert(storage.get(row)).toString());
     }
   }
 
   // Spark expects DateType as Integer number of days since UNIX epoch.
-  static class DateReader implements VortexValueReader<Integer> {
-    static final DateReader INSTANCE = new DateReader();
-
-    private DateReader() {}
+  static class DateReader extends BoundVortexReader<Integer> {
+    private DateDayVector dayVector;
+    private DateMilliVector milliVector;
 
     @Override
-    public Integer readNonNull(FieldVector vector, int row) {
-      ArrowType arrowType = vector.getField().getType();
-      if (arrowType instanceof ArrowType.Date dateType
-          && dateType.getUnit() == org.apache.arrow.vector.types.DateUnit.MILLISECOND) {
-        long millis = ((DateMilliVector) vector).get(row);
-        return DateTimeUtil.microsToDays(millis * 1000L);
+    protected void bindVector(FieldVector vector) {
+      if (vector instanceof DateMilliVector dateMilliVector) {
+        this.milliVector = dateMilliVector;
+        this.dayVector = null;
+      } else {
+        this.dayVector = (DateDayVector) vector;
+        this.milliVector = null;
       }
-      return ((DateDayVector) vector).get(row);
+    }
+
+    @Override
+    public Integer readNonNull(int row) {
+      if (milliVector != null) {
+        return DateTimeUtil.microsToDays(milliVector.get(row) * 1000L);
+      }
+      return dayVector.get(row);
     }
   }
 
-  static class TimestampReader implements VortexValueReader<Long> {
+  static class TimestampReader extends BoundVortexReader<Long> {
     private final TimeUnit unit;
+    private TimeStampVector timestampVector;
+    private BigIntVector longVector;
 
     private TimestampReader(TimeUnit unit) {
       this.unit = unit;
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      long measure;
+    protected void bindVector(FieldVector vector) {
       if (vector instanceof TimeStampVector ts) {
-        measure = ts.get(row);
+        this.timestampVector = ts;
+        this.longVector = null;
       } else {
-        measure = ((BigIntVector) vector).get(row);
+        this.longVector = (BigIntVector) vector;
+        this.timestampVector = null;
       }
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      long measure = timestampVector != null ? timestampVector.get(row) : longVector.get(row);
       return switch (unit) {
         case NANOSECOND -> Math.floorDiv(measure, 1_000L);
         case MICROSECOND -> measure;
@@ -231,22 +275,39 @@ public class SparkVortexValueReaders {
     }
   }
 
-  static class TimeReader implements VortexValueReader<Long> {
+  static class TimeReader extends BoundVortexReader<Long> {
     private final TimeUnit unit;
+    private TimeMicroVector microVector;
+    private TimeNanoVector nanoVector;
+    private BigIntVector longVector;
 
     private TimeReader(TimeUnit unit) {
       this.unit = unit;
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      long measure;
+    protected void bindVector(FieldVector vector) {
+      this.microVector = null;
+      this.nanoVector = null;
+      this.longVector = null;
       if (vector instanceof TimeMicroVector tm) {
-        measure = tm.get(row);
+        this.microVector = tm;
       } else if (vector instanceof TimeNanoVector tn) {
-        measure = tn.get(row);
+        this.nanoVector = tn;
       } else {
-        measure = ((BigIntVector) vector).get(row);
+        this.longVector = (BigIntVector) vector;
+      }
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      long measure;
+      if (microVector != null) {
+        measure = microVector.get(row);
+      } else if (nanoVector != null) {
+        measure = nanoVector.get(row);
+      } else {
+        measure = longVector.get(row);
       }
       return switch (unit) {
         case NANOSECOND -> Math.floorDiv(measure, 1_000L);
@@ -260,21 +321,24 @@ public class SparkVortexValueReaders {
   // Converts the Iceberg Variant produced by the shared Vortex reader into Spark's VariantVal by
   // re-serializing metadata and value to little-endian buffers (mirrors SparkParquetReaders).
   static class VariantReader implements VortexValueReader<VariantVal> {
-    static final VariantReader INSTANCE = new VariantReader();
-
     private final VortexValueReader<Variant> delegate = GenericVortexReaders.variants();
 
     private VariantReader() {}
 
     @Override
-    public VariantVal read(FieldVector vector, int row) {
-      Variant variant = delegate.read(vector, row);
+    public void bind(FieldVector vector) {
+      delegate.bind(vector);
+    }
+
+    @Override
+    public VariantVal read(int row) {
+      Variant variant = delegate.read(row);
       return variant == null ? null : toVariantVal(variant);
     }
 
     @Override
-    public VariantVal readNonNull(FieldVector vector, int row) {
-      return toVariantVal(delegate.readNonNull(vector, row));
+    public VariantVal readNonNull(int row) {
+      return toVariantVal(delegate.readNonNull(row));
     }
 
     private static VariantVal toVariantVal(Variant variant) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkVortexReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkVortexReaders.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexBatchReader;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -40,6 +41,14 @@ import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class VectorizedSparkVortexReaders {
+
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; Spark always calls isNullAt before value getters, so
+    // Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private VectorizedSparkVortexReaders() {}
 
   public static VortexBatchReader<ColumnarBatch> buildReader(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VortexArrowColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VortexArrowColumnVector.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.util.List;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -41,8 +42,6 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
-import org.apache.arrow.vector.holders.NullableLargeVarCharHolder;
-import org.apache.arrow.vector.holders.NullableVarCharHolder;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -54,6 +53,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -331,19 +331,44 @@ class VortexArrowColumnVector extends ColumnVector {
     throw new UnsupportedOperationException("Unsupported Arrow type: " + arrowType);
   }
 
+  /**
+   * Base accessor reading vector memory directly by address (Comet-style). The null count is
+   * computed once per batch column (Arrow rescans the validity bitmap on every {@code
+   * getNullCount()} call) and null checks read the validity bit directly, skipping Arrow's per-call
+   * bounds checks. Value getters may return garbage for null slots, which is allowed by Spark's
+   * {@link ColumnVector} contract: callers check {@code isNullAt} (or {@code hasNull}) first.
+   */
   private abstract static class ArrowVectorAccessor {
+    // Marks a vector with null slots but no validity buffer (NullVector): every slot is null.
+    private static final long ALL_NULL = -1L;
+
     private final ValueVector vector;
+    private final int nullCount;
+    private final long validityAddress;
 
     ArrowVectorAccessor(ValueVector vector) {
       this.vector = vector;
+      this.nullCount = vector.getNullCount();
+      if (vector instanceof NullVector) {
+        this.validityAddress = ALL_NULL;
+      } else if (nullCount > 0) {
+        this.validityAddress = vector.getValidityBuffer().memoryAddress();
+      } else {
+        this.validityAddress = 0L;
+      }
     }
 
     final boolean isNullAt(int rowId) {
-      return vector.isNull(rowId);
+      if (nullCount == 0) {
+        return false;
+      } else if (validityAddress == ALL_NULL) {
+        return true;
+      }
+      return (Platform.getByte(null, validityAddress + (rowId >>> 3)) & (1 << (rowId & 7))) == 0;
     }
 
     final int getNullCount() {
-      return vector.getNullCount();
+      return nullCount;
     }
 
     boolean getBoolean(int rowId) {
@@ -396,175 +421,197 @@ class VortexArrowColumnVector extends ColumnVector {
   }
 
   private static final class BooleanAccessor extends ArrowVectorAccessor {
-    private final BitVector accessor;
+    private final long dataAddress;
 
     BooleanAccessor(BitVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     boolean getBoolean(int rowId) {
-      return accessor.get(rowId) == 1;
+      return (Platform.getByte(null, dataAddress + (rowId >>> 3)) & (1 << (rowId & 7))) != 0;
     }
   }
 
   private static final class ByteAccessor extends ArrowVectorAccessor {
-    private final TinyIntVector accessor;
+    private final long dataAddress;
 
     ByteAccessor(TinyIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     byte getByte(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getByte(null, dataAddress + rowId);
     }
   }
 
   private static final class ShortAccessor extends ArrowVectorAccessor {
-    private final SmallIntVector accessor;
+    private final long dataAddress;
 
     ShortAccessor(SmallIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     short getShort(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getShort(null, dataAddress + ((long) rowId << 1));
     }
   }
 
   private static final class IntAccessor extends ArrowVectorAccessor {
-    private final IntVector accessor;
+    private final long dataAddress;
 
     IntAccessor(IntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     int getInt(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getInt(null, dataAddress + ((long) rowId << 2));
     }
   }
 
   private static final class LongAccessor extends ArrowVectorAccessor {
-    private final BigIntVector accessor;
+    private final long dataAddress;
 
     LongAccessor(BigIntVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     long getLong(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getLong(null, dataAddress + ((long) rowId << 3));
     }
   }
 
   private static final class FloatAccessor extends ArrowVectorAccessor {
-    private final Float4Vector accessor;
+    private final long dataAddress;
 
     FloatAccessor(Float4Vector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     float getFloat(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getFloat(null, dataAddress + ((long) rowId << 2));
     }
   }
 
   private static final class DoubleAccessor extends ArrowVectorAccessor {
-    private final Float8Vector accessor;
+    private final long dataAddress;
 
     DoubleAccessor(Float8Vector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     double getDouble(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getDouble(null, dataAddress + ((long) rowId << 3));
     }
   }
 
   private static final class DecimalAccessor extends ArrowVectorAccessor {
+    private static final int TYPE_WIDTH = 16;
+
     private final DecimalVector accessor;
+    private final long dataAddress;
 
     DecimalAccessor(DecimalVector vector) {
       super(vector);
       this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     Decimal getDecimal(int rowId, int precision, int scale) {
+      if (precision <= Decimal.MAX_LONG_DIGITS()) {
+        // Arrow decimal128 values are little-endian two's complement; a value that fits in
+        // precision <= 18 digits fits in a long, so its low 8 bytes are the full value with the
+        // upper half being sign extension. Only valid on little-endian hardware.
+        long unscaled = Platform.getLong(null, dataAddress + (long) rowId * TYPE_WIDTH);
+        return Decimal.createUnsafe(unscaled, precision, scale);
+      }
       return Decimal.apply(accessor.getObject(rowId), precision, scale);
     }
   }
 
   private static final class StringAccessor extends ArrowVectorAccessor {
-    private final VarCharVector accessor;
-    private final NullableVarCharHolder stringResult = new NullableVarCharHolder();
+    private final long offsetAddress;
+    private final long dataAddress;
 
     StringAccessor(VarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.offsetAddress = vector.getOffsetBuffer().memoryAddress();
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      accessor.get(rowId, stringResult);
-      if (stringResult.isSet == 0) {
-        return null;
-      }
-      return UTF8String.fromAddress(
-          null,
-          stringResult.buffer.memoryAddress() + stringResult.start,
-          stringResult.end - stringResult.start);
+      int start = Platform.getInt(null, offsetAddress + ((long) rowId << 2));
+      int end = Platform.getInt(null, offsetAddress + ((long) (rowId + 1) << 2));
+      return UTF8String.fromAddress(null, dataAddress + start, end - start);
     }
   }
 
   private static final class LargeStringAccessor extends ArrowVectorAccessor {
-    private final LargeVarCharVector accessor;
-    private final NullableLargeVarCharHolder stringResult = new NullableLargeVarCharHolder();
+    private final long offsetAddress;
+    private final long dataAddress;
 
     LargeStringAccessor(LargeVarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.offsetAddress = vector.getOffsetBuffer().memoryAddress();
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      accessor.get(rowId, stringResult);
-      if (stringResult.isSet == 0) {
-        return null;
-      }
+      long start = Platform.getLong(null, offsetAddress + ((long) rowId << 3));
+      long end = Platform.getLong(null, offsetAddress + ((long) (rowId + 1) << 3));
       // A single string cannot be larger than the max integer size, so the cast is safe.
-      return UTF8String.fromAddress(
-          null,
-          stringResult.buffer.memoryAddress() + stringResult.start,
-          (int) (stringResult.end - stringResult.start));
+      return UTF8String.fromAddress(null, dataAddress + start, (int) (end - start));
     }
   }
 
   private static final class StringViewAccessor extends ArrowVectorAccessor {
-    private final ViewVarCharVector accessor;
+    // See the Arrow Utf8View spec: 16-byte views of {length, prefix|inline data, buffer id,
+    // offset}; values of 12 bytes or fewer are inlined into the view itself.
+    private static final int VIEW_SIZE = 16;
+    private static final int INLINE_SIZE = 12;
+
+    private final long viewAddress;
+    private final long[] dataBufferAddresses;
 
     StringViewAccessor(ViewVarCharVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.viewAddress = vector.getDataBuffer().memoryAddress();
+      List<ArrowBuf> dataBuffers = vector.getDataBuffers();
+      this.dataBufferAddresses = new long[dataBuffers.size()];
+      for (int i = 0; i < dataBuffers.size(); i++) {
+        this.dataBufferAddresses[i] = dataBuffers.get(i).memoryAddress();
+      }
     }
 
     @Override
     UTF8String getUTF8String(int rowId) {
-      // View values may be inlined in the view buffer rather than contiguous in a data buffer,
-      // so copy out rather than aliasing vector memory.
-      return UTF8String.fromBytes(accessor.get(rowId));
+      long view = viewAddress + (long) rowId * VIEW_SIZE;
+      int length = Platform.getInt(null, view);
+      if (length <= INLINE_SIZE) {
+        // Inline values live in the view buffer itself, which shares the batch's lifetime, so
+        // aliasing it is as safe as aliasing a data buffer.
+        return UTF8String.fromAddress(null, view + 4, length);
+      }
+
+      int bufferIndex = Platform.getInt(null, view + 8);
+      int dataOffset = Platform.getInt(null, view + 12);
+      return UTF8String.fromAddress(null, dataBufferAddresses[bufferIndex] + dataOffset, length);
     }
   }
 
@@ -611,16 +658,16 @@ class VortexArrowColumnVector extends ColumnVector {
   }
 
   private static final class DateAccessor extends ArrowVectorAccessor {
-    private final DateDayVector accessor;
+    private final long dataAddress;
 
     DateAccessor(DateDayVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
     }
 
     @Override
     int getInt(int rowId) {
-      return accessor.get(rowId);
+      return Platform.getInt(null, dataAddress + ((long) rowId << 2));
     }
   }
 
@@ -631,18 +678,18 @@ class VortexArrowColumnVector extends ColumnVector {
    * matching Spark's nanosecond-to-microsecond conversions.
    */
   private static final class TimestampAccessor extends ArrowVectorAccessor {
-    private final TimeStampVector accessor;
+    private final long dataAddress;
     private final org.apache.arrow.vector.types.TimeUnit unit;
 
     TimestampAccessor(TimeStampVector vector) {
       super(vector);
-      this.accessor = vector;
+      this.dataAddress = vector.getDataBuffer().memoryAddress();
       this.unit = ((ArrowType.Timestamp) vector.getField().getType()).getUnit();
     }
 
     @Override
     long getLong(int rowId) {
-      long value = accessor.get(rowId);
+      long value = Platform.getLong(null, dataAddress + ((long) rowId << 3));
       return switch (unit) {
         case SECOND -> Math.multiplyExact(value, 1_000_000L);
         case MILLISECOND -> Math.multiplyExact(value, 1_000L);

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReader.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReader.java
@@ -168,16 +168,25 @@ public class GenericVortexReader implements VortexRowReader<Record> {
   }
 
   @Override
-  public Record read(VectorSchemaRoot batch, int row) {
+  public void newBatch(VectorSchemaRoot batch) {
     if (batchColumnIndex == null) {
       this.batchColumnIndex = resolveColumns(batch);
     }
 
-    GenericRecord record = container();
     for (int i = 0; i < readers.length; i++) {
       int columnIndex = batchColumnIndex[i];
-      FieldVector vector = columnIndex < 0 ? null : batch.getVector(columnIndex);
-      record.set(i, readers[i].read(vector, row));
+      if (columnIndex >= 0) {
+        readers[i].bind(batch.getVector(columnIndex));
+      }
+    }
+  }
+
+  @Override
+  public Record read(int row) {
+    Preconditions.checkState(batchColumnIndex != null, "newBatch must be called before read");
+    GenericRecord record = container();
+    for (int i = 0; i < readers.length; i++) {
+      record.set(i, readers[i].read(row));
     }
     return record;
   }

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
@@ -79,9 +79,9 @@ public class GenericVortexReaders {
   private GenericVortexReaders() {}
 
   /**
-   * Mirrors the vectorized read path: a decimal with precision of at most 18 digits fits in a
-   * long, so its little-endian decimal128 low 8 bytes are the full value with the upper half being
-   * sign extension. Reading them directly avoids materializing a 16-byte array and a {@link
+   * Mirrors the vectorized read path: a decimal with precision of at most 18 digits fits in a long,
+   * so its little-endian decimal128 low 8 bytes are the full value with the upper half being sign
+   * extension. Reading them directly avoids materializing a 16-byte array and a {@link
    * java.math.BigInteger} per value. Only valid on little-endian hardware.
    */
   private static BigDecimal readBigDecimal(DecimalVector vector, int row) {

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
@@ -30,7 +30,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.IntStream;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -69,10 +69,28 @@ import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.variants.Variants;
+import org.apache.iceberg.vortex.BoundVortexReader;
+import org.apache.iceberg.vortex.VortexArrowProperties;
 import org.apache.iceberg.vortex.VortexSchemas;
 import org.apache.iceberg.vortex.VortexValueReader;
 
+/**
+ * Value readers for Arrow batches produced by Vortex scans.
+ *
+ * <p>Readers are stateful: {@link VortexValueReader#bind(FieldVector)} must be called with each new
+ * batch's vector before reading rows. Binding hoists per-batch work out of the per-row path:
+ * validity is checked against the bound null count and validity buffer instead of per-row {@code
+ * isNull} calls, struct children are resolved by name once instead of per row, and decimal
+ * precision/scale and data buffers are captured once per batch.
+ */
 public class GenericVortexReaders {
+  static {
+    // Configure Arrow's unsafe-memory-access and null-check-for-get properties like
+    // VectorizedSparkParquetReaders does; readers always check nullability before value getters,
+    // so Arrow's per-get null checks and bounds checks are redundant on this path.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   // Largest decimal precision whose unscaled value always fits in a long.
   private static final int MAX_LONG_PRECISION = 18;
 
@@ -94,24 +112,24 @@ public class GenericVortexReaders {
   }
 
   public static VortexValueReader<Boolean> bools() {
-    return BooleanReader.INSTANCE;
+    return new BooleanReader();
   }
 
   public static VortexValueReader<Integer> ints() {
-    return IntegerReader.INSTANCE;
+    return new IntegerReader();
   }
 
   public static VortexValueReader<BigDecimal> decimals() {
-    return DecimalReader.INSTANCE;
+    return new DecimalReader();
   }
 
   public static VortexValueReader<Long> longs() {
-    return LongReader.INSTANCE;
+    return new LongReader();
   }
 
   /** Reader for int columns projected as longs (schema evolution int-to-long promotion). */
   public static VortexValueReader<Long> intsAsLongs() {
-    return IntAsLongReader.INSTANCE;
+    return new LongReader();
   }
 
   /**
@@ -130,41 +148,41 @@ public class GenericVortexReaders {
 
   /** Reader for float columns projected as doubles (schema evolution float-to-double promotion). */
   public static VortexValueReader<Double> floatsAsDoubles() {
-    return FloatAsDoubleReader.INSTANCE;
+    return new FloatAsDoubleReader();
   }
 
   public static VortexValueReader<Float> floats() {
-    return FloatReader.INSTANCE;
+    return new FloatReader();
   }
 
   public static VortexValueReader<Double> doubles() {
-    return DoubleReader.INSTANCE;
+    return new DoubleReader();
   }
 
   public static VortexValueReader<String> strings() {
-    return StringReader.INSTANCE;
+    return new StringReader();
   }
 
   /** Reader for Utf8View columns, which Vortex scans return for strings. */
   public static VortexValueReader<String> stringsView() {
-    return StringViewReader.INSTANCE;
+    return new StringViewReader();
   }
 
   public static VortexValueReader<ByteBuffer> bytes() {
-    return BytesReader.INSTANCE;
+    return new BytesReader();
   }
 
   /** Reader for BinaryView columns, which Vortex scans return for binary. */
   public static VortexValueReader<ByteBuffer> bytesView() {
-    return BytesViewReader.INSTANCE;
+    return new BytesViewReader();
   }
 
   public static VortexValueReader<UUID> uuids() {
-    return UuidReader.INSTANCE;
+    return new UuidReader();
   }
 
   public static VortexValueReader<Variant> variants() {
-    return VariantReader.INSTANCE;
+    return new VariantReader();
   }
 
   public static VortexValueReader<LocalDate> date(boolean isMillis) {
@@ -193,7 +211,7 @@ public class GenericVortexReaders {
   }
 
   /**
-   * Returns a reader that always produces {@code constant}, ignoring the Arrow vector and row.
+   * Returns a reader that always produces {@code constant}, ignoring the bound vector and row.
    *
    * <p>Used to inject identity-partition values and metadata columns (for example {@code _file} or
    * {@code _spec_id}) that are supplied through {@code idToConstant} rather than being read from
@@ -203,7 +221,7 @@ public class GenericVortexReaders {
     return new ConstantReader<>(constant);
   }
 
-  private static class StructReader implements VortexValueReader<Record> {
+  private static class StructReader extends BoundVortexReader<Record> {
     private final Types.StructType schema;
     // File column name backing each expected field, or null when the field is absent from the file.
     private final String[] childNames;
@@ -238,38 +256,51 @@ public class GenericVortexReaders {
     }
 
     @Override
-    public Record readNonNull(FieldVector vector, int row) {
+    protected void bindVector(FieldVector vector) {
       StructVector struct = (StructVector) vector;
+      for (int i = 0; i < childNames.length; i++) {
+        if (childNames[i] != null) {
+          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
+          Preconditions.checkState(
+              child != null, "Vortex batch is missing struct child: %s", childNames[i]);
+          readers.get(i).bind(child);
+        }
+      }
+    }
+
+    @Override
+    public Record readNonNull(int row) {
       GenericRecord record = GenericRecord.create(schema);
       for (int i = 0; i < readers.size(); i++) {
-        VortexValueReader<?> reader = readers.get(i);
-        if (childNames[i] == null) {
-          record.set(i, reader.read(null, row));
-        } else {
-          FieldVector child = (FieldVector) struct.getChild(childNames[i]);
-          record.set(i, reader.read(child, row));
-        }
+        record.set(i, readers.get(i).read(row));
       }
       return record;
     }
   }
 
-  private static class ListReader<T> implements VortexValueReader<List<T>> {
+  private static class ListReader<T> extends BoundVortexReader<List<T>> {
     private final VortexValueReader<T> elementReader;
+    private ListVector listVector;
 
     private ListReader(VortexValueReader<T> elementReader) {
       this.elementReader = elementReader;
     }
 
     @Override
-    public List<T> readNonNull(FieldVector vector, int row) {
-      ListVector listVector = (ListVector) vector;
+    protected void bindVector(FieldVector vector) {
+      this.listVector = (ListVector) vector;
+      elementReader.bind(listVector.getDataVector());
+    }
+
+    @Override
+    public List<T> readNonNull(int row) {
       int start = listVector.getElementStartIndex(row);
       int end = listVector.getElementEndIndex(row);
-      FieldVector elementVector = listVector.getDataVector();
-      return IntStream.range(start, end)
-          .mapToObj(i -> elementReader.read(elementVector, i))
-          .toList();
+      List<T> elements = Lists.newArrayListWithCapacity(end - start);
+      for (int i = start; i < end; i++) {
+        elements.add(elementReader.read(i));
+      }
+      return elements;
     }
   }
 
@@ -281,193 +312,250 @@ public class GenericVortexReaders {
     }
 
     @Override
-    public C read(FieldVector vector, int row) {
+    public C read(int row) {
       return constant;
     }
 
     @Override
-    public C readNonNull(FieldVector vector, int row) {
+    public C readNonNull(int row) {
       return constant;
     }
   }
 
-  private static class BooleanReader implements VortexValueReader<Boolean> {
-    static final BooleanReader INSTANCE = new BooleanReader();
-
-    private BooleanReader() {}
+  private static class BooleanReader extends BoundVortexReader<Boolean> {
+    private ArrowBuf data;
 
     @Override
-    public Boolean readNonNull(FieldVector vector, int row) {
-      return ((BitVector) vector).get(row) != 0;
+    protected void bindVector(FieldVector vector) {
+      this.data = ((BitVector) vector).getDataBuffer();
+    }
+
+    @Override
+    public Boolean readNonNull(int row) {
+      return (data.getByte(row >>> 3) & (1 << (row & 7))) != 0;
     }
   }
 
-  private static class IntegerReader implements VortexValueReader<Integer> {
-    static final IntegerReader INSTANCE = new IntegerReader();
-
-    private IntegerReader() {}
+  private static class IntegerReader extends BoundVortexReader<Integer> {
+    private BaseIntVector intVector;
 
     @Override
-    public Integer readNonNull(FieldVector vector, int row) {
-      return (int) ((BaseIntVector) vector).getValueAsLong(row);
+    protected void bindVector(FieldVector vector) {
+      this.intVector = (BaseIntVector) vector;
+    }
+
+    @Override
+    public Integer readNonNull(int row) {
+      return (int) intVector.getValueAsLong(row);
     }
   }
 
-  private static class LongReader implements VortexValueReader<Long> {
-    static final LongReader INSTANCE = new LongReader();
-
-    private LongReader() {}
+  private static class LongReader extends BoundVortexReader<Long> {
+    private BaseIntVector intVector;
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      return ((BaseIntVector) vector).getValueAsLong(row);
+    protected void bindVector(FieldVector vector) {
+      this.intVector = (BaseIntVector) vector;
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      return intVector.getValueAsLong(row);
     }
   }
 
-  private static class DecimalReader implements VortexValueReader<BigDecimal> {
-    static final DecimalReader INSTANCE = new DecimalReader();
-
-    private DecimalReader() {}
+  private static class DecimalReader extends BoundVortexReader<BigDecimal> {
+    private DecimalVector decimalVector;
+    private ArrowBuf data;
+    private int scale;
+    private boolean fitsInLong;
 
     @Override
-    public BigDecimal readNonNull(FieldVector vector, int row) {
-      return readBigDecimal((DecimalVector) vector, row);
+    protected void bindVector(FieldVector vector) {
+      this.decimalVector = (DecimalVector) vector;
+      this.data = vector.getDataBuffer();
+      this.scale = decimalVector.getScale();
+      this.fitsInLong = decimalVector.getPrecision() <= MAX_LONG_PRECISION;
+    }
+
+    @Override
+    public BigDecimal readNonNull(int row) {
+      if (fitsInLong) {
+        // See readBigDecimal: the low 8 little-endian bytes carry the full value.
+        long unscaled = data.getLong((long) row * DecimalVector.TYPE_WIDTH);
+        return BigDecimal.valueOf(unscaled, scale);
+      }
+
+      return decimalVector.getObjectNotNull(row);
     }
   }
 
-  private static class FloatReader implements VortexValueReader<Float> {
-    static final FloatReader INSTANCE = new FloatReader();
-
-    private FloatReader() {}
+  private static class FloatReader extends BoundVortexReader<Float> {
+    private Float4Vector floatVector;
 
     @Override
-    public Float readNonNull(FieldVector vector, int row) {
-      return ((Float4Vector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.floatVector = (Float4Vector) vector;
+    }
+
+    @Override
+    public Float readNonNull(int row) {
+      return floatVector.get(row);
     }
   }
 
-  private static class DoubleReader implements VortexValueReader<Double> {
-    static final DoubleReader INSTANCE = new DoubleReader();
-
-    private DoubleReader() {}
+  private static class DoubleReader extends BoundVortexReader<Double> {
+    private Float8Vector doubleVector;
 
     @Override
-    public Double readNonNull(FieldVector vector, int row) {
-      return ((Float8Vector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.doubleVector = (Float8Vector) vector;
+    }
+
+    @Override
+    public Double readNonNull(int row) {
+      return doubleVector.get(row);
     }
   }
 
-  private static class IntAsLongReader implements VortexValueReader<Long> {
-    static final IntAsLongReader INSTANCE = new IntAsLongReader();
-
-    private IntAsLongReader() {}
+  private static class FloatAsDoubleReader extends BoundVortexReader<Double> {
+    private Float4Vector floatVector;
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      return ((BaseIntVector) vector).getValueAsLong(row);
+    protected void bindVector(FieldVector vector) {
+      this.floatVector = (Float4Vector) vector;
+    }
+
+    @Override
+    public Double readNonNull(int row) {
+      return (double) floatVector.get(row);
     }
   }
 
   private static class RowIdReader implements VortexValueReader<Long> {
     private final long firstRowId;
+    private BaseIntVector valueVector;
+    private ArrowBuf valueValidity;
+    private BaseIntVector posVector;
 
     private RowIdReader(long firstRowId) {
       this.firstRowId = firstRowId;
     }
 
     @Override
-    public Long read(FieldVector vector, int row) {
-      // the packed struct itself is never null
-      return readNonNull(vector, row);
+    public void bind(FieldVector vector) {
+      StructVector struct = (StructVector) vector;
+      FieldVector value = (FieldVector) struct.getChild("value");
+      this.valueVector = (BaseIntVector) value;
+      this.valueValidity =
+          value != null && value.getNullCount() > 0 ? value.getValidityBuffer() : null;
+      this.posVector = (BaseIntVector) struct.getChild("pos");
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      StructVector struct = (StructVector) vector;
-      FieldVector value = (FieldVector) struct.getChild("value");
-      if (value != null && !value.isNull(row)) {
-        return ((BaseIntVector) value).getValueAsLong(row);
+    public Long read(int row) {
+      // the packed struct itself is never null
+      return readNonNull(row);
+    }
+
+    @Override
+    public Long readNonNull(int row) {
+      if (valueVector != null && !isValueNull(row)) {
+        return valueVector.getValueAsLong(row);
       }
 
-      FieldVector pos = (FieldVector) struct.getChild("pos");
-      return firstRowId + ((BaseIntVector) pos).getValueAsLong(row);
+      return firstRowId + posVector.getValueAsLong(row);
+    }
+
+    private boolean isValueNull(int row) {
+      return valueValidity != null && (valueValidity.getByte(row >>> 3) & (1 << (row & 7))) == 0;
     }
   }
 
   private static class LongOrDefaultReader implements VortexValueReader<Long> {
     private final long defaultValue;
+    private BaseIntVector longVector;
+    private ArrowBuf validity;
 
     private LongOrDefaultReader(long defaultValue) {
       this.defaultValue = defaultValue;
     }
 
     @Override
-    public Long read(FieldVector vector, int row) {
-      if (vector == null || vector.isNull(row)) {
+    public void bind(FieldVector vector) {
+      this.longVector = (BaseIntVector) vector;
+      this.validity = vector.getNullCount() > 0 ? vector.getValidityBuffer() : null;
+    }
+
+    @Override
+    public Long read(int row) {
+      if (longVector == null
+          || (validity != null && (validity.getByte(row >>> 3) & (1 << (row & 7))) == 0)) {
         return defaultValue;
       }
 
-      return readNonNull(vector, row);
+      return readNonNull(row);
     }
 
     @Override
-    public Long readNonNull(FieldVector vector, int row) {
-      return ((BaseIntVector) vector).getValueAsLong(row);
-    }
-  }
-
-  private static class FloatAsDoubleReader implements VortexValueReader<Double> {
-    static final FloatAsDoubleReader INSTANCE = new FloatAsDoubleReader();
-
-    private FloatAsDoubleReader() {}
-
-    @Override
-    public Double readNonNull(FieldVector vector, int row) {
-      return (double) ((Float4Vector) vector).get(row);
+    public Long readNonNull(int row) {
+      return longVector.getValueAsLong(row);
     }
   }
 
-  private static class StringReader implements VortexValueReader<String> {
-    static final StringReader INSTANCE = new StringReader();
-
-    private StringReader() {}
+  private static class StringReader extends BoundVortexReader<String> {
+    private VarCharVector stringVector;
 
     @Override
-    public String readNonNull(FieldVector vector, int row) {
-      return new String(((VarCharVector) vector).get(row), StandardCharsets.UTF_8);
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (VarCharVector) vector;
+    }
+
+    @Override
+    public String readNonNull(int row) {
+      return new String(stringVector.get(row), StandardCharsets.UTF_8);
     }
   }
 
-  private static class StringViewReader implements VortexValueReader<String> {
-    static final StringViewReader INSTANCE = new StringViewReader();
-
-    private StringViewReader() {}
+  private static class StringViewReader extends BoundVortexReader<String> {
+    private ViewVarCharVector stringVector;
 
     @Override
-    public String readNonNull(FieldVector vector, int row) {
-      return new String(((ViewVarCharVector) vector).get(row), StandardCharsets.UTF_8);
+    protected void bindVector(FieldVector vector) {
+      this.stringVector = (ViewVarCharVector) vector;
+    }
+
+    @Override
+    public String readNonNull(int row) {
+      return new String(stringVector.get(row), StandardCharsets.UTF_8);
     }
   }
 
-  private static class BytesReader implements VortexValueReader<ByteBuffer> {
-    static final BytesReader INSTANCE = new BytesReader();
-
-    private BytesReader() {}
+  private static class BytesReader extends BoundVortexReader<ByteBuffer> {
+    private VarBinaryVector binaryVector;
 
     @Override
-    public ByteBuffer readNonNull(FieldVector vector, int row) {
-      return ByteBuffer.wrap(((VarBinaryVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (VarBinaryVector) vector;
+    }
+
+    @Override
+    public ByteBuffer readNonNull(int row) {
+      return ByteBuffer.wrap(binaryVector.get(row));
     }
   }
 
-  private static class BytesViewReader implements VortexValueReader<ByteBuffer> {
-    static final BytesViewReader INSTANCE = new BytesViewReader();
-
-    private BytesViewReader() {}
+  private static class BytesViewReader extends BoundVortexReader<ByteBuffer> {
+    private ViewVarBinaryVector binaryVector;
 
     @Override
-    public ByteBuffer readNonNull(FieldVector vector, int row) {
-      return ByteBuffer.wrap(((ViewVarBinaryVector) vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.binaryVector = (ViewVarBinaryVector) vector;
+    }
+
+    @Override
+    public ByteBuffer readNonNull(int row) {
+      return ByteBuffer.wrap(binaryVector.get(row));
     }
   }
 
@@ -490,14 +578,17 @@ public class GenericVortexReaders {
     return ((VarBinaryVector) vector).get(row);
   }
 
-  private static class UuidReader implements VortexValueReader<UUID> {
-    static final UuidReader INSTANCE = new UuidReader();
-
-    private UuidReader() {}
+  private static class UuidReader extends BoundVortexReader<UUID> {
+    private FixedSizeBinaryVector storage;
 
     @Override
-    public UUID readNonNull(FieldVector vector, int row) {
-      return UUIDUtil.convert(uuidStorage(vector).get(row));
+    protected void bindVector(FieldVector vector) {
+      this.storage = uuidStorage(vector);
+    }
+
+    @Override
+    public UUID readNonNull(int row) {
+      return UUIDUtil.convert(storage.get(row));
     }
   }
 
@@ -515,26 +606,28 @@ public class GenericVortexReaders {
   }
 
   private static class VariantReader implements VortexValueReader<Variant> {
-    static final VariantReader INSTANCE = new VariantReader();
+    private FieldVector outerVector;
+    private StructVector storage;
 
     private VariantReader() {}
 
     @Override
-    public Variant read(FieldVector vector, int row) {
-      StructVector storage = variantStorage(vector);
-      if (vector.isNull(row)) {
-        return null;
-      }
-
-      return readVariant(storage, row);
+    public void bind(FieldVector vector) {
+      this.outerVector = vector;
+      this.storage = variantStorage(vector);
     }
 
     @Override
-    public Variant readNonNull(FieldVector vector, int row) {
-      return readVariant(variantStorage(vector), row);
+    public Variant read(int row) {
+      if (outerVector.isNull(row)) {
+        return null;
+      }
+
+      return readNonNull(row);
     }
 
-    private Variant readVariant(StructVector storage, int row) {
+    @Override
+    public Variant readNonNull(int row) {
       FieldVector metadataVector = (FieldVector) storage.getChild("metadata");
       if (metadataVector == null || metadataVector.isNull(row)) {
         throw new IllegalStateException("Invalid Vortex variant: metadata is null");
@@ -737,36 +830,53 @@ public class GenericVortexReaders {
     return (StructVector) vector;
   }
 
-  private static class DateReader implements VortexValueReader<LocalDate> {
+  private static class DateReader extends BoundVortexReader<LocalDate> {
     private final boolean isMillis;
+    private DateDayVector dayVector;
+    private DateMilliVector milliVector;
 
     DateReader(boolean isMillis) {
       this.isMillis = isMillis;
     }
 
     @Override
-    public LocalDate readNonNull(FieldVector vector, int row) {
+    protected void bindVector(FieldVector vector) {
+      if (isMillis) {
+        this.milliVector = (DateMilliVector) vector;
+      } else {
+        this.dayVector = (DateDayVector) vector;
+      }
+    }
+
+    @Override
+    public LocalDate readNonNull(int row) {
       int days;
       if (isMillis) {
-        days = (int) Math.floorDiv(((DateMilliVector) vector).get(row), 86_400_000L);
+        days = (int) Math.floorDiv(milliVector.get(row), 86_400_000L);
       } else {
-        days = ((DateDayVector) vector).get(row);
+        days = dayVector.get(row);
       }
 
       return DateTimeUtil.dateFromDays(days);
     }
   }
 
-  private static class TimestampReader implements VortexValueReader<LocalDateTime> {
+  private static class TimestampReader extends BoundVortexReader<LocalDateTime> {
     private final boolean nanosecond;
+    private TimeStampVector timestampVector;
 
     private TimestampReader(boolean nanosecond) {
       this.nanosecond = nanosecond;
     }
 
     @Override
-    public LocalDateTime readNonNull(FieldVector vector, int row) {
-      long measure = ((TimeStampVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.timestampVector = (TimeStampVector) vector;
+    }
+
+    @Override
+    public LocalDateTime readNonNull(int row) {
+      long measure = timestampVector.get(row);
       if (nanosecond) {
         return DateTimeUtil.timestampFromNanos(measure);
       } else {
@@ -775,26 +885,38 @@ public class GenericVortexReaders {
     }
   }
 
-  private static class TimeReader implements VortexValueReader<LocalTime> {
+  private static class TimeReader extends BoundVortexReader<LocalTime> {
     private final boolean nanosecond;
+    private TimeNanoVector nanoVector;
+    private TimeMicroVector microVector;
 
     private TimeReader(boolean nanosecond) {
       this.nanosecond = nanosecond;
     }
 
     @Override
-    public LocalTime readNonNull(FieldVector vector, int row) {
+    protected void bindVector(FieldVector vector) {
       if (nanosecond) {
-        return LocalTime.ofNanoOfDay(((TimeNanoVector) vector).get(row));
+        this.nanoVector = (TimeNanoVector) vector;
       } else {
-        return DateTimeUtil.timeFromMicros(((TimeMicroVector) vector).get(row));
+        this.microVector = (TimeMicroVector) vector;
+      }
+    }
+
+    @Override
+    public LocalTime readNonNull(int row) {
+      if (nanosecond) {
+        return LocalTime.ofNanoOfDay(nanoVector.get(row));
+      } else {
+        return DateTimeUtil.timeFromMicros(microVector.get(row));
       }
     }
   }
 
-  private static class TimestampTzReader implements VortexValueReader<OffsetDateTime> {
+  private static class TimestampTzReader extends BoundVortexReader<OffsetDateTime> {
     private final ZoneId timeZone;
     private final boolean nanosecond;
+    private TimeStampVector timestampVector;
 
     private TimestampTzReader(String timeZone, boolean nanosecond) {
       this.timeZone = ZoneId.of(timeZone);
@@ -802,8 +924,13 @@ public class GenericVortexReaders {
     }
 
     @Override
-    public OffsetDateTime readNonNull(FieldVector vector, int row) {
-      long measure = ((TimeStampVector) vector).get(row);
+    protected void bindVector(FieldVector vector) {
+      this.timestampVector = (TimeStampVector) vector;
+    }
+
+    @Override
+    public OffsetDateTime readNonNull(int row) {
+      long measure = timestampVector.get(row);
       long nanoAdjustment;
       if (nanosecond) {
         nanoAdjustment = measure;

--- a/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
+++ b/vortex/src/main/java/org/apache/iceberg/data/vortex/GenericVortexReaders.java
@@ -73,7 +73,25 @@ import org.apache.iceberg.vortex.VortexSchemas;
 import org.apache.iceberg.vortex.VortexValueReader;
 
 public class GenericVortexReaders {
+  // Largest decimal precision whose unscaled value always fits in a long.
+  private static final int MAX_LONG_PRECISION = 18;
+
   private GenericVortexReaders() {}
+
+  /**
+   * Mirrors the vectorized read path: a decimal with precision of at most 18 digits fits in a
+   * long, so its little-endian decimal128 low 8 bytes are the full value with the upper half being
+   * sign extension. Reading them directly avoids materializing a 16-byte array and a {@link
+   * java.math.BigInteger} per value. Only valid on little-endian hardware.
+   */
+  private static BigDecimal readBigDecimal(DecimalVector vector, int row) {
+    if (vector.getPrecision() <= MAX_LONG_PRECISION) {
+      long unscaled = vector.getDataBuffer().getLong((long) row * DecimalVector.TYPE_WIDTH);
+      return BigDecimal.valueOf(unscaled, vector.getScale());
+    }
+
+    return vector.getObjectNotNull(row);
+  }
 
   public static VortexValueReader<Boolean> bools() {
     return BooleanReader.INSTANCE;
@@ -313,7 +331,7 @@ public class GenericVortexReaders {
 
     @Override
     public BigDecimal readNonNull(FieldVector vector, int row) {
-      return ((DecimalVector) vector).getObjectNotNull(row);
+      return readBigDecimal((DecimalVector) vector, row);
     }
   }
 
@@ -605,7 +623,7 @@ public class GenericVortexReaders {
         physicalType = PhysicalType.DECIMAL16;
       }
 
-      return Variants.of(physicalType, ((DecimalVector) vector).getObjectNotNull(row));
+      return Variants.of(physicalType, readBigDecimal((DecimalVector) vector, row));
     } else if (type instanceof ArrowType.Date dateType) {
       int days =
           switch (dateType.getUnit()) {

--- a/vortex/src/main/java/org/apache/iceberg/vortex/BoundVortexReader.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/BoundVortexReader.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.vortex;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.FieldVector;
+
+/**
+ * Base {@link VortexValueReader} that captures per-batch state on {@link #bind(FieldVector)}. Null
+ * checks read the bound validity buffer directly, skipping per-row {@code isNull} calls entirely
+ * for all-valid vectors. {@link #bind(FieldVector)} must be called before any row is read.
+ */
+public abstract class BoundVortexReader<D> implements VortexValueReader<D> {
+  // Validity bitmap of the bound vector, or null when every slot is valid.
+  private ArrowBuf validity = null;
+
+  @Override
+  public final void bind(FieldVector vector) {
+    this.validity = vector.getNullCount() > 0 ? vector.getValidityBuffer() : null;
+    bindVector(vector);
+  }
+
+  /** Captures reader-specific state (typed vectors, buffers, children) for the bound vector. */
+  protected abstract void bindVector(FieldVector vector);
+
+  protected final boolean isNullAt(int row) {
+    return validity != null && (validity.getByte(row >>> 3) & (1 << (row & 7))) == 0;
+  }
+
+  @Override
+  public final D read(int row) {
+    if (isNullAt(row)) {
+      return null;
+    }
+
+    return readNonNull(row);
+  }
+}

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexArrowProperties.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexArrowProperties.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.vortex;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configures Arrow's global memory-access properties for Vortex reads, mirroring the behavior of
+ * {@code VectorizedSparkParquetReaders}. Must run before any Arrow buffer class is initialized
+ * (both the Vortex-relocated and the engine-facing Arrow copies read these properties in static
+ * initializers), so callers invoke {@link #ensureConfigured()} from their own static blocks.
+ */
+public final class VortexArrowProperties {
+
+  private static final Logger LOG = LoggerFactory.getLogger(VortexArrowProperties.class);
+  private static final String ENABLE_UNSAFE_MEMORY_ACCESS = "arrow.enable_unsafe_memory_access";
+  private static final String ENABLE_UNSAFE_MEMORY_ACCESS_ENV = "ARROW_ENABLE_UNSAFE_MEMORY_ACCESS";
+  private static final String ENABLE_NULL_CHECK_FOR_GET = "arrow.enable_null_check_for_get";
+  private static final String ENABLE_NULL_CHECK_FOR_GET_ENV = "ARROW_ENABLE_NULL_CHECK_FOR_GET";
+
+  private static volatile boolean configured = false;
+
+  static {
+    ensureConfigured();
+  }
+
+  private VortexArrowProperties() {}
+
+  public static void ensureConfigured() {
+    if (configured) {
+      return;
+    }
+
+    synchronized (VortexArrowProperties.class) {
+      if (configured) {
+        return;
+      }
+
+      try {
+        enableUnsafeMemoryAccess();
+        disableNullCheckForGet();
+      } catch (Exception e) {
+        LOG.warn("Couldn't set Arrow properties, which may impact read performance", e);
+      }
+
+      configured = true;
+    }
+  }
+
+  // enables unsafe memory access to avoid costly checks to see if index is within bounds
+  // as long as it is not configured explicitly (see BoundsChecking in Arrow)
+  private static void enableUnsafeMemoryAccess() {
+    String value = confValue(ENABLE_UNSAFE_MEMORY_ACCESS, ENABLE_UNSAFE_MEMORY_ACCESS_ENV);
+    if (value == null) {
+      LOG.info("Enabling {}", ENABLE_UNSAFE_MEMORY_ACCESS);
+      System.setProperty(ENABLE_UNSAFE_MEMORY_ACCESS, "true");
+    } else {
+      LOG.info("Unsafe memory access was configured explicitly: {}", value);
+    }
+  }
+
+  // disables expensive null checks for every get call in favor of Iceberg nullability
+  // as long as it is not configured explicitly (see NullCheckingForGet in Arrow)
+  private static void disableNullCheckForGet() {
+    String value = confValue(ENABLE_NULL_CHECK_FOR_GET, ENABLE_NULL_CHECK_FOR_GET_ENV);
+    if (value == null) {
+      LOG.info("Disabling {}", ENABLE_NULL_CHECK_FOR_GET);
+      System.setProperty(ENABLE_NULL_CHECK_FOR_GET, "false");
+    } else {
+      LOG.info("Null checking for get calls was configured explicitly: {}", value);
+    }
+  }
+
+  private static String confValue(String propName, String envName) {
+    String propValue = System.getProperty(propName);
+    if (propValue != null) {
+      return propValue;
+    }
+
+    return System.getenv(envName);
+  }
+}

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexFormatModel.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexFormatModel.java
@@ -58,6 +58,13 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 public class VortexFormatModel<D, S, R>
     extends BaseFormatModel<D, S, VortexValueWriter<?>, R, Schema> {
+
+  static {
+    // Must run before either Arrow copy (Vortex-relocated or engine-facing) initializes its
+    // buffer classes, which read these properties in static initializers.
+    VortexArrowProperties.ensureConfigured();
+  }
+
   private final boolean isBatchReader;
 
   public interface ReaderFunction<R> {
@@ -259,7 +266,7 @@ public class VortexFormatModel<D, S, R>
       BufferAllocator allocator = VortexArrowBridge.arrowAllocator();
       dev.vortex.relocated.org.apache.arrow.memory.BufferAllocator vortexAllocator =
           VortexArrowBridge.vortexAllocator();
-      Session session = Session.create();
+      Session session = VortexSessions.shared();
 
       // Stream the file through the table's FileIO instead of Vortex's native storage clients.
       // The appender owns the sink and closes it after the writer is finalized.

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexIterable.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexIterable.java
@@ -108,7 +108,7 @@ public class VortexIterable<T> extends CloseableGroup implements CloseableIterab
     // begins for this read.
     NativeRuntime.setWorkerThreads(workerThreads);
 
-    Session session = Session.create();
+    Session session = VortexSessions.shared();
     // Read through the table's FileIO instead of Vortex's native storage clients. The returned
     // iterator owns the readable and closes it when the scan is exhausted or abandoned.
     NativeReadable readable = VortexIO.readable(inputFile);

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexIterable.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexIterable.java
@@ -199,6 +199,13 @@ public class VortexIterable<T> extends CloseableGroup implements CloseableIterab
             false);
 
     ImmutableScanOptions.Builder optionsBuilder = ScanOptions.builder().projection(scanProjection);
+    // Vortex scans resolve partitions concurrently and yield them out of order by default. Row
+    // readers surface records positionally (like every other iceberg file format reader), so the
+    // row path must preserve file order. The batch path stays unordered: Spark derives row
+    // positions from the scan's row_idx values rather than emission order.
+    if (rowReaderFunc != null) {
+      optionsBuilder.ordered(true);
+    }
     scanFilter.ifPresent(optionsBuilder::filter);
     if (rowRange != null) {
       optionsBuilder.rowRangeBegin(rowRange[0]).rowRangeEnd(rowRange[1]);
@@ -427,6 +434,7 @@ public class VortexIterable<T> extends CloseableGroup implements CloseableIterab
         currentBatch = batches.next();
         batchIndex = 0;
         batchLen = currentBatch.getRowCount();
+        rowReader.newBatch(currentBatch);
         if (batchLen > 0) {
           return true;
         }
@@ -442,7 +450,7 @@ public class VortexIterable<T> extends CloseableGroup implements CloseableIterab
       if (!hasNext()) {
         throw new NoSuchElementException();
       }
-      T nextRow = rowReader.read(currentBatch, batchIndex);
+      T nextRow = rowReader.read(batchIndex);
       batchIndex++;
       return nextRow;
     }

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexRowReader.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexRowReader.java
@@ -20,9 +20,20 @@ package org.apache.iceberg.vortex;
 
 import org.apache.arrow.vector.VectorSchemaRoot;
 
-/** Reads a single row of type {@link T} from an Arrow {@link VectorSchemaRoot} batch. */
+/**
+ * Reads rows of type {@link T} from Arrow {@link VectorSchemaRoot} batches. Callers must invoke
+ * {@link #newBatch(VectorSchemaRoot)} each time they advance to a new batch, then read rows by
+ * their position within that batch.
+ */
 public interface VortexRowReader<T> {
-  T read(VectorSchemaRoot batch, int row);
+  /**
+   * Binds this reader to {@code batch} for subsequent {@link #read} calls, hoisting per-batch work
+   * (column resolution, buffer and null-count binding) out of the per-row path.
+   */
+  void newBatch(VectorSchemaRoot batch);
+
+  /** Reads the row at {@code row} within the current batch. */
+  T read(int row);
 
   /**
    * Requests that {@link #read} refill and return the same top-level container instance on every

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexSessions.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexSessions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.vortex;
+
+import dev.vortex.api.Session;
+
+/**
+ * Provides the process-wide shared Vortex {@link Session}.
+ *
+ * <p>Creating a session builds the full native encoding/kernel registries and is expensive, so a
+ * single session is shared by all readers and writers in the JVM (sessions are documented as safe
+ * to share across threads). The session lives for the lifetime of the process; its native resources
+ * are reclaimed on JVM exit.
+ */
+public final class VortexSessions {
+
+  private VortexSessions() {}
+
+  private static final class Holder {
+    private static final Session SHARED = Session.create();
+  }
+
+  public static Session shared() {
+    return Holder.SHARED;
+  }
+}

--- a/vortex/src/main/java/org/apache/iceberg/vortex/VortexValueReader.java
+++ b/vortex/src/main/java/org/apache/iceberg/vortex/VortexValueReader.java
@@ -20,15 +20,24 @@ package org.apache.iceberg.vortex;
 
 import org.apache.arrow.vector.FieldVector;
 
-/** Reads a {@link D} from an Arrow {@link FieldVector} at a row. */
+/**
+ * Reads a {@link D} from a bound Arrow {@link FieldVector} at a row.
+ *
+ * <p>Readers are bound to a vector once per batch via {@link #bind(FieldVector)} and then read rows
+ * from it, letting them hoist per-batch work (null counts, buffers, child vector resolution) out of
+ * the per-row path. {@link #bind(FieldVector)} must be called before rows are read and again
+ * whenever a new batch arrives.
+ */
 public interface VortexValueReader<D> {
-  default D read(FieldVector vector, int row) {
-    if (vector.isNull(row)) {
-      return null;
-    } else {
-      return readNonNull(vector, row);
-    }
-  }
+  /**
+   * Binds this reader to the vector it will read from until the next call. The default is a no-op
+   * for readers that do not read from a vector (constants).
+   */
+  default void bind(FieldVector vector) {}
 
-  D readNonNull(FieldVector vector, int row);
+  /** Reads the value at {@code row}, or null when the slot is null. */
+  D read(int row);
+
+  /** Reads the value at {@code row}, which must be a non-null slot. */
+  D readNonNull(int row);
 }

--- a/vortex/src/test/java/org/apache/iceberg/data/vortex/TestGenericVortexVariantReaders.java
+++ b/vortex/src/test/java/org/apache/iceberg/data/vortex/TestGenericVortexVariantReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.variants.Variants;
+import org.apache.iceberg.vortex.VortexValueReader;
 import org.junit.jupiter.api.Test;
 
 class TestGenericVortexVariantReaders {
@@ -60,7 +61,9 @@ class TestGenericVortexVariantReaders {
       vector.setIndexDefined(0);
       vector.setValueCount(1);
 
-      Variant actual = GenericVortexReaders.variants().read(vector, 0);
+      VortexValueReader<Variant> variantReader = GenericVortexReaders.variants();
+      variantReader.bind(vector);
+      Variant actual = variantReader.read(0);
 
       assertThat(actual.value().type()).isEqualTo(PhysicalType.INT32);
       assertThat(actual.value().asPrimitive().get()).isEqualTo(34);
@@ -105,7 +108,9 @@ class TestGenericVortexVariantReaders {
       vector.setIndexDefined(0);
       vector.setValueCount(1);
 
-      Variant actual = GenericVortexReaders.variants().read(vector, 0);
+      VortexValueReader<Variant> variantReader = GenericVortexReaders.variants();
+      variantReader.bind(vector);
+      Variant actual = variantReader.read(0);
 
       assertThat(actual.value().type()).isEqualTo(PhysicalType.OBJECT);
       assertThat(actual.value().asObject().get("a").asPrimitive().get()).isEqualTo(10);
@@ -139,7 +144,9 @@ class TestGenericVortexVariantReaders {
       vector.setIndexDefined(0);
       vector.setValueCount(1);
 
-      Variant actual = GenericVortexReaders.variants().read(vector, 0);
+      VortexValueReader<Variant> variantReader = GenericVortexReaders.variants();
+      variantReader.bind(vector);
+      Variant actual = variantReader.read(0);
 
       assertThat(actual.value().type()).isEqualTo(PhysicalType.ARRAY);
       assertThat(actual.value().asArray().numElements()).isEqualTo(2);

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestGenericVortex.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestGenericVortex.java
@@ -97,9 +97,9 @@ public class TestGenericVortex extends DataTestBase {
   }
 
   /**
-   * Reads a file large enough for the scan to return multiple Arrow batches, verifying that
-   * readers re-bind their cached buffers and null state on every batch rather than reading through
-   * stale bindings from the first one.
+   * Reads a file large enough for the scan to return multiple Arrow batches, verifying that readers
+   * re-bind their cached buffers and null state on every batch rather than reading through stale
+   * bindings from the first one.
    */
   @Test
   public void testMultipleBatchesRebindReaders() throws IOException {

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestGenericVortex.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestGenericVortex.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.vortex;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -38,9 +39,84 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
+import org.junit.jupiter.api.Test;
 
 public class TestGenericVortex extends DataTestBase {
+
+  /**
+   * Row readers surface rows positionally, so a file spanning multiple scan partitions must read
+   * back in file order. Vortex resolves partitions concurrently and only preserves order when the
+   * scan requests it, which single-batch tests never exercise.
+   */
+  @Test
+  public void testMultiBatchReadsPreserveRowOrder() throws IOException {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(100, "id", Types.LongType.get()),
+            Types.NestedField.optional(101, "data", Types.StringType.get()),
+            Types.NestedField.optional(102, "num", Types.DecimalType.of(11, 2)),
+            Types.NestedField.optional(
+                103,
+                "location",
+                StructType.of(
+                    Types.NestedField.optional(104, "inner_id", Types.IntegerType.get()),
+                    Types.NestedField.optional(105, "inner_data", Types.StringType.get()))));
+    List<Record> randoms = RandomGenericData.generate(schema, 150_000, 42L);
+    List<Record> expected = Lists.newArrayListWithCapacity(150_000);
+    for (long i = 0; i < 150_000; i++) {
+      Record copy = randoms.get((int) i).copy();
+      copy.set(0, i);
+      expected.add(copy);
+    }
+
+    OutputFile outputFile =
+        Files.localOutput(temp.resolve("test-seq-" + System.nanoTime() + ".vortex").toFile());
+    try (FileAppender<Record> appender =
+        formatModel()
+            .writeBuilder(EncryptedFiles.plainAsEncryptedOutput(outputFile))
+            .schema(schema)
+            .content(FileContent.DATA)
+            .build()) {
+      appender.addAll(expected);
+    }
+
+    List<Long> actualIds = Lists.newArrayList();
+    try (CloseableIterable<Record> reader =
+        formatModel().readBuilder(outputFile.toInputFile()).project(schema).build()) {
+      for (Record record : reader) {
+        actualIds.add((Long) record.get(0));
+      }
+    }
+
+    assertThat(actualIds).hasSize(150_000);
+    for (int i = 0; i < actualIds.size(); i++) {
+      assertThat(actualIds.get(i)).as("row %s must be read in file order", i).isEqualTo((long) i);
+    }
+  }
+
+  /**
+   * Reads a file large enough for the scan to return multiple Arrow batches, verifying that
+   * readers re-bind their cached buffers and null state on every batch rather than reading through
+   * stale bindings from the first one.
+   */
+  @Test
+  public void testMultipleBatchesRebindReaders() throws IOException {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(100, "id", Types.LongType.get()),
+            Types.NestedField.optional(101, "data", Types.StringType.get()),
+            Types.NestedField.optional(102, "num", Types.DecimalType.of(11, 2)),
+            Types.NestedField.optional(
+                103,
+                "location",
+                StructType.of(
+                    Types.NestedField.optional(104, "inner_id", Types.IntegerType.get()),
+                    Types.NestedField.optional(105, "inner_data", Types.StringType.get()))));
+    writeAndValidate(schema, RandomGenericData.generate(schema, 150_000, 42L));
+  }
+
   @Override
   protected boolean supportsUnknown() {
     return false;

--- a/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexUuid.java
+++ b/vortex/src/test/java/org/apache/iceberg/vortex/TestVortexUuid.java
@@ -84,8 +84,9 @@ public class TestVortexUuid {
       // Read back using the GenericVortexReader's primitive dispatch through GenericVortexReaders.
       VortexRowReader<Record> reader =
           GenericVortexReader.buildReader(SCHEMA, VortexSchemas.toArrowSchema(SCHEMA));
-      Record row0 = reader.read(root, 0);
-      Record row1 = reader.read(root, 1);
+      reader.newBatch(root);
+      Record row0 = reader.read(0);
+      Record row1 = reader.read(1);
 
       assertThat(row0.get(0)).isEqualTo(1L);
       assertThat(row0.get(1)).isEqualTo(uuid1);
@@ -117,7 +118,9 @@ public class TestVortexUuid {
           .setSafe(0, org.apache.iceberg.util.UUIDUtil.convert(uuid));
       root.setRowCount(1);
 
-      assertThat(GenericVortexReaders.uuids().read(root.getVector(0), 0)).isEqualTo(uuid);
+      VortexValueReader<UUID> uuidReader = GenericVortexReaders.uuids();
+      uuidReader.bind(root.getVector(0));
+      assertThat(uuidReader.read(0)).isEqualTo(uuid);
     }
   }
 


### PR DESCRIPTION
This mirrors parquet behaviour where spark guarantees null checks before any
value lookup, we know the values are well formed on export so we can directly
refence memory addresses instead of going through arrow-java bound checks

Avoid recreating VortexSession for every file, this is meant to be shared for
a whole scan
